### PR TITLE
Fix two blockers that killed remote training after the dep upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,21 +15,17 @@ WORKDIR /workspace
 ENV PATH="/workspace/.venv/bin:$PATH"
 ENV PYTHONPATH="/workspace"
 
-# -m gives nonroot a real home. Without it, libraries that write per-user config
-# (ultralytics, matplotlib) fail on /home/nonroot and fall back to /tmp -- matplotlib
-# warns this slows imports and hurts multiprocessing, which affects dataloader workers.
-RUN groupadd -r nonroot && useradd -r -m -g nonroot nonroot
-
 # Install the application dependencies.
-# chown runs inside this same layer on purpose: as a separate `RUN chown -R`, Docker's
-# copy-on-write duplicates the whole ~8GB venv into a second layer, doubling the image.
 RUN --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-dev --no-cache \
-    && chown -R nonroot:nonroot /workspace/.venv \
-    && chown nonroot:nonroot /workspace
+    uv sync --frozen --no-dev --no-cache
 
 # Copy the application into the container.
-COPY --chown=nonroot:nonroot ./src /workspace/src
+COPY ./src /workspace/src
 
-USER nonroot
+# Deliberately runs as root. clearml-agent's docker-mode bootstrap needs it: it writes
+# /etc/apt/apt.conf.d/, chowns /root/.cache/pip, copies /root/.ssh and runs apt-get.
+# Under `USER nonroot` every one of those fails and the task hangs before reaching
+# src/train.py -- verified against task f206e189 on NEW-gpu-machine-server2.
+# Dropping the nonroot user also removes the `chown -R` that was duplicating the
+# whole ~8GB venv into a second layer.

--- a/src/yolov8/metrics_utils.py
+++ b/src/yolov8/metrics_utils.py
@@ -108,14 +108,27 @@ def extract_loss_components(trainer: BaseTrainer) -> dict[str, float]:
     """
     losses = {}
 
-    if hasattr(trainer, "loss_items") and trainer.loss_items is not None:
-        loss_names = getattr(trainer, "loss_names", ["box_loss", "cls_loss", "dfl_loss"])
-        for name, value in zip(loss_names, trainer.loss_items, strict=False):
+    # Ultralytics >=8.4 made loss_items and tloss dicts of {name: value}; before that
+    # loss_items was a tensor of values zipped against loss_names, and tloss a scalar.
+    # Iterating a dict yields its keys, so the old zip silently paired names with names
+    # and float() blew up on 'box_loss'. Handle both shapes.
+    loss_items = getattr(trainer, "loss_items", None)
+    if isinstance(loss_items, dict):
+        losses.update({name: float(value) for name, value in loss_items.items()})
+    elif loss_items is not None:
+        loss_names = getattr(trainer, "loss_names", None) or (
+            "box_loss",
+            "cls_loss",
+            "dfl_loss",
+        )
+        for name, value in zip(loss_names, loss_items, strict=False):
             losses[name] = float(value)
 
-    # Also try to get from tloss
-    if hasattr(trainer, "tloss") and trainer.tloss is not None:
-        losses["total_loss"] = float(trainer.tloss)
+    tloss = getattr(trainer, "tloss", None)
+    if isinstance(tloss, dict):
+        losses["total_loss"] = float(sum(tloss.values()))
+    elif tloss is not None:
+        losses["total_loss"] = float(tloss)
 
     return losses
 

--- a/tests/yolov8/test_metrics_utils.py
+++ b/tests/yolov8/test_metrics_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from src.yolov8.metrics_utils import (
     collect_prediction_confidences,
@@ -127,8 +128,8 @@ class TestExtractLossComponents:
         result = extract_loss_components(trainer)
         assert result == {}
 
-    def test_returns_loss_components(self):
-        """Test that function returns individual loss components."""
+    def test_returns_loss_components_legacy_sequence(self):
+        """Test the pre-8.4 shape: loss_items a sequence, tloss a scalar."""
         trainer = MagicMock()
         trainer.loss_items = [0.5, 0.3, 0.2]
         trainer.loss_names = ["box_loss", "cls_loss", "dfl_loss"]
@@ -141,6 +142,26 @@ class TestExtractLossComponents:
         assert result["cls_loss"] == 0.3
         assert result["dfl_loss"] == 0.2
         assert result["total_loss"] == 1.0
+
+    def test_returns_loss_components_dict_shape(self):
+        """Test the ultralytics >=8.4 shape: loss_items and tloss are dicts.
+
+        Regression guard. Iterating a dict yields its keys, so the old
+        zip(loss_names, loss_items) paired names with names and float() raised
+        ValueError: could not convert string to float: 'box_loss' -- which killed
+        training at the first on_train_epoch_end callback.
+        """
+        trainer = MagicMock()
+        trainer.loss_items = {"box_loss": 0.5, "cls_loss": 0.3, "dfl_loss": 0.2}
+        trainer.loss_names = tuple(trainer.loss_items)
+        trainer.tloss = {"box_loss": 0.4, "cls_loss": 0.2, "dfl_loss": 0.1}
+
+        result = extract_loss_components(trainer)
+
+        assert result["box_loss"] == 0.5
+        assert result["cls_loss"] == 0.3
+        assert result["dfl_loss"] == 0.2
+        assert result["total_loss"] == pytest.approx(0.7)
 
 
 class TestExtractLearningRate:


### PR DESCRIPTION
Follow-up to #8. Both bugs were found by **actually running a task on an agent** — a 3-epoch clone of `e21fac5f` as [`f206e189`](http://10.8.0.10:7080/projects/2496ecc8d7704c7ba9fbe5d3bc81f2eb/tasks/f206e18991684466bcab72cea1f6f249) on `NEW-gpu-machine-server2`. Neither was caught by the test suite, nor by importing the whole stack inside the container.

## 1. `USER nonroot` broke remote execution entirely

clearml-agent's docker-mode bootstrap runs as the image's `USER` and needs root — it writes `/etc/apt/apt.conf.d/`, chowns `/root/.cache/pip`, copies `/root/.ssh`, and runs `apt-get`. Under `USER nonroot` all of it fails and the task hangs before ever reaching `src/train.py`:

```
bash: /etc/apt/apt.conf.d/docker-clean: Permission denied
chown: cannot access '/root/.cache/pip': Permission denied
cp: cannot stat '/root/.ssh': Permission denied
E: Unable to acquire the dpkg frontend lock ... are you root?
```

The comparison that settles it:

```
image serving the agents for ~10 months : User=
image built from main                   : User=nonroot
```

The nonroot block was enabled in `661a5b7` but **never exercised**, because the image was not rebuilt after that commit. Merging #8 and promoting a rebuilt image would have taken down every GPU queue — with no relation to the dependency upgrade itself.

Side benefit: without the nonroot user there is no `chown -R` to fold anywhere, so the ~8GB venv duplication problem disappears rather than being worked around. Image stays at 8.94GB.

## 2. `extract_loss_components` died at the first epoch callback

ultralytics >=8.4 turned `trainer.loss_items` and `trainer.tloss` into dicts of `{name: value}`. They used to be a tensor of values and a scalar. Iterating a dict yields its **keys**, so `zip(loss_names, loss_items)` paired names with names:

```
callbacks.py:191      on_train_epoch_end -> extract_loss_components(trainer)
metrics_utils.py:114  losses[name] = float(value)
ValueError: could not convert string to float: 'box_loss'
```

Confirmed in the installed ultralytics source:

```python
trainer.py:99   tloss (dict): Running mean of loss items.
trainer.py:481  self.loss_names = tuple(self.loss_items)          # tuple(dict) -> keys
trainer.py:488  {k: (self.tloss[k]*i + v)/(i+1) for k, v in self.loss_items.items()}
```

`float(trainer.tloss)` on line 118 would have failed next for the same reason. Now handles both shapes.

### Why the tests did not catch it

```python
trainer = MagicMock()
trainer.loss_items = [0.5, 0.3, 0.2]     # the pre-8.4 contract
```

The test encodes our old assumption, and `MagicMock` accepts anything, so it passes regardless of what ultralytics actually does. Added a regression test for the dict shape.

## Verification

Full pipeline on the agent, after both fixes:

| stage | result |
|---|---|
| 53 CVAT task exports (CVAT 1.7, raw HTTP) | all completed |
| COCO->YOLO + split | 5137 train / 1427 val / 47 test |
| Training (ultralytics 8.4.110, torch 2.9.1+cu128, GPU) | 3 epochs, 2.6 min |
| mAP50 progression | 0.548 -> 0.848 -> 0.948, `best.pt` 0.946 |
| Scalar charts | 11 (losses incl. total_loss, LR, P/R/mAP, speed) |
| Plots | 14 (confusion matrix, PR/F1/P/R curves, per-class) |
| `YOLO.val()` on test split | mAP50 0.795 over 47 images |
| Debug images | 19 (Mosaic, Validation, Prediction) |
| Registered models | `pytorch-yolov8s-best`, `pytorch-yolov8s-last` |
| Task status | **completed** |

`pytest`: 54 passed, 1 pre-existing failure (`test_converter_coco2yolo`, needs a local `tmp_dir_cvat/` fixture; fails identically on the pre-upgrade baseline).

## Not covered

**`export_handler()` never ran.** Every format on this task is `0`:

```
torchscript onnx openvino engine coreml saved_model pb tflite edgetpu tfjs paddle
     0       0      0       0       0        0       0     0      0      0      0
```

So **onnx 1.17.0 -> 1.22.0 and openvino 2025.1.0 -> 2026.2.1 are still untested.** If export is used anywhere, that needs its own run with a format enabled.

Also worth knowing, found while reading the traceback: `PYTHONPATH=/workspace` makes `src.yolov8.*` resolve to the copy **baked into the image**, while `src/train.py` comes from the git clone:

```
.../template-yolov8-clearml.git/src/train.py     <- git
/workspace/src/yolov8/callbacks.py               <- image
```

So changes under `src/yolov8/` take effect only after an image rebuild, and the two can drift silently. Not changed here, but it is why fixing `metrics_utils.py` in git alone did nothing until the image was rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)