### PR TITLE
Add fast export smoke tests and document agent gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,10 @@ make run                    # PYTHONPATH=. uv run src/train.py
 
 # Run tests
 make test_code              # pytest tests -v
+PYTHONPATH=. uv run pytest -m "not slow"    # skip tests that invoke real exporters
+
+# Test the export stage on its own (~7s, no CVAT, no training, no weights download)
+PYTHONPATH=. uv run pytest tests/yolov8/test_export_smoke.py
 
 # Linting and formatting (via pre-commit or directly)
 uv run ruff check --fix     # Lint with auto-fix
@@ -84,6 +88,28 @@ YOLO Training
 - Double quotes for strings
 - Ruff for linting/formatting with rules: E, F, I, UP, B, W, C90, N, D, PYI, PT, RET, SIM, ARG, ERA
 - Pre-commit hooks configured
+
+## Gotchas When Running on an Agent
+
+- **The image shadows `src/`.** The container sets `PYTHONPATH=/workspace` and bakes a
+  copy of `src/` in, so `src.yolov8.*` resolves to the **image's** copy while
+  `src/train.py` runs from the git checkout. Editing anything under `src/yolov8/` has no
+  effect on a remote run until the image is rebuilt (`make build`). The two can drift
+  silently.
+- **The container runs as root on purpose.** clearml-agent's docker-mode bootstrap writes
+  to `/etc/apt`, `/root/.cache/pip` and `/root/.ssh` and runs `apt-get`. Adding a
+  `USER` directive to the Dockerfile makes every remote task hang before reaching
+  `src/train.py`.
+- **`torch` is pinned to a CUDA 12.x wheel window** (`>=2.9,<2.10`). Newer torch resolves
+  to a CUDA 13 wheel that needs a much newer driver and, if unmet, silently falls back to
+  CPU instead of erroring. Check every agent host's driver before widening it.
+- **A task pins its own commit.** `version_num` on an existing task wins over its branch
+  name, so editing the branch alone does not move it to newer code; clear the commit to
+  follow the branch. Agents also cache clones per repo, and a stale cache can write an old
+  branch name back onto the task after execution.
+- **Deprecated export args.** `args_export["params"]` still uses `half` and `int8`, which
+  ultralytics has replaced with `quantize`. Tolerated today; `tests/yolov8/test_export_smoke.py`
+  fails when that stops being true.
 
 ## ClearML Integration Points
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,6 @@ env =
     CVAT_OUTPUT_DIR=
 
 addopts = -p no:warnings
+
+markers =
+    slow: invokes a real exporter or model build; a few seconds each

--- a/tests/yolov8/test_export_smoke.py
+++ b/tests/yolov8/test_export_smoke.py
@@ -1,0 +1,81 @@
+"""Fast smoke tests for the export stage.
+
+Export needs nothing but a model file, so these run without CVAT, without
+training and without downloading weights -- the model is built from its yaml
+config. A few seconds each, versus ~15 minutes to reach the export stage
+through a full pipeline run.
+
+Marked `slow` because they still invoke real ONNX/OpenVINO exporters. Run them
+with `pytest -m slow`, or skip with `pytest -m "not slow"`.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from ultralytics import YOLO
+
+from src.params import args_export
+from src.yolov8.exporter import export_model_format, filter_export_parameters
+
+
+# Small model + small imgsz keeps each export to a couple of seconds. Built from
+# yaml rather than a .pt so no network access is needed; random weights are fine
+# because we assert on the exporter, not on predictions.
+MODEL_CONFIG = "yolov8n.yaml"
+IMGSZ = 320
+
+
+@pytest.fixture(scope="module")
+def model() -> YOLO:
+    """Untrained model built from config -- no weights download."""
+    return YOLO(MODEL_CONFIG)
+
+
+@pytest.fixture
+def workdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run each export in its own directory; ultralytics writes next to cwd."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("format_model", ["onnx", "openvino"])
+def test_export_with_project_params(
+    model: YOLO,
+    workdir: Path,
+    format_model: str,
+) -> None:
+    """Export succeeds using the parameters the pipeline actually sends.
+
+    Doubles as a deprecation guard: args_export carries `half` and `int8`, both
+    of which ultralytics has replaced with `quantize` and dropped from
+    default.yaml. They are still tolerated, so this passes -- when a future
+    release stops accepting them it fails here rather than mid-training.
+    """
+    exported = Path(
+        str(export_model_format(model, format_model, IMGSZ, dict(args_export["params"])))
+    ).resolve()
+
+    assert exported.exists(), f"{format_model} produced no artifact"
+    assert exported.is_relative_to(workdir), f"{format_model} wrote outside the tmp dir"
+
+
+@pytest.mark.parametrize("format_model", ["onnx", "openvino", "torchscript"])
+def test_filter_export_parameters_drops_unsupported(format_model: str) -> None:
+    """Only parameters the format understands survive filtering.
+
+    No export involved, so this stays fast and always runs.
+    """
+    filtered = filter_export_parameters(format_model, dict(args_export["params"]))
+
+    assert filtered, f"{format_model} got no parameters at all"
+    assert set(filtered) <= set(args_export["params"]), "filter invented a parameter"
+    assert "keras" not in filtered, "keras is not valid for these formats"
+
+
+def test_engine_format_bypasses_filtering() -> None:
+    """TensorRT is special-cased in the exporter and keeps every parameter."""
+    params = dict(args_export["params"])
+
+    assert filter_export_parameters("engine", params) == params


### PR DESCRIPTION
The export stage was the last part of the pipeline with no coverage, and the only way to reach it was a full run: clone a task, pull dozens of CVAT exports, train, then export. Roughly **15 minutes to exercise a call that takes three seconds**.

Export needs nothing but a model, so these tests build one from its yaml config — no weights download, no network — and call `export_model_format` directly.

```
pytest tests/yolov8/test_export_smoke.py     6 passed in ~7s
pytest -m "not slow"                         skips the real exporters, ~3s
```

Registered the `slow` marker in `pytest.ini` so the exporter-invoking cases can be deselected in pre-commit while the parameter-filtering cases still run.

## Doubles as a deprecation guard

The ONNX/OpenVINO case passes `args_export["params"]` verbatim rather than a hand-written dict. That matters: those params carry `half` and `int8`, and current ultralytics has replaced both with `quantize` and dropped them from its `default.yaml`:

```yaml
quantize:  # ... replaces deprecated half/int8 args
```

They are still tolerated, so the test passes today. When a release stops accepting them it fails here — in seconds, locally — instead of part-way through a training run.

This is exactly the class of thing the existing suite could not catch. The bug fixed in #9 slipped through because its test mocked our own assumption about the ultralytics API rather than the API itself.

## Documented gotchas

Five things in `CLAUDE.md` that are invisible from the code and cost real debugging time:

- **The image shadows `src/`.** The container sets `PYTHONPATH=/workspace` and bakes a copy of `src/` in, so `src.yolov8.*` resolves to the image's copy while `src/train.py` runs from the git checkout. Editing anything under `src/yolov8/` has no effect on a remote run until the image is rebuilt, and the two can drift silently.
- **The container runs as root on purpose.** The agent's docker-mode bootstrap writes to `/etc/apt`, `/root/.cache/pip` and `/root/.ssh`. A `USER` directive makes every remote task hang before reaching `src/train.py` — see #9.
- **`torch` is windowed to a CUDA 12.x wheel.** Newer torch resolves to a CUDA 13 wheel that needs a much newer driver and, if unmet, silently falls back to CPU instead of erroring.
- **A task pins its own commit.** `version_num` wins over the branch name, so editing the branch alone does not move a task to newer code. Agents also cache clones per repo, and a stale cache can write an old branch name back onto the task after execution.
- **The deprecated export args** above.

## Verification

```
pytest tests -q          60 passed, 1 pre-existing failure
ruff check               clean
```

The pre-existing failure is `test_converter_coco2yolo`, which needs a local dataset fixture and fails identically on `main`.