### PR TITLE
Make pipeline logs greppable and stop them scaling with the dataset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ make test_fast              # skip tests that invoke real exporters
 # Test the export stage on its own (~7s, no CVAT, no training, no weights download)
 PYTHONPATH=. uv run pytest tests/yolov8/test_export_smoke.py
 
+# Test the data stage on its own (<1s, builds a mini COCO tree in tmp_path).
+# Also asserts log volume does not grow with dataset size.
+PYTHONPATH=. uv run pytest tests/data/test_data_stage_smoke.py
+
 # Linting and formatting (via pre-commit or directly)
 uv run ruff check --fix     # Lint with auto-fix
 uv run ruff format          # Format code
@@ -92,6 +96,45 @@ YOLO Training
   `clearml_project` / `clearml_task_name`, which are read before `Task.connect()` and
   therefore only apply to a locally launched first run.
 
+## Logging
+
+Everything goes through `src/utils/logging.py`. `print()` is banned — ruff `T20`
+enforces it and `tests/utils/test_no_print.py` covers the `from rich import print`
+alias that `T20` cannot see.
+
+| Level | Meaning |
+|---|---|
+| ERROR | the run is affected: an export failed, validation crashed |
+| WARNING | degraded but continuing: CVAT export timed out, unpaired labels |
+| INFO | stage boundaries, and **one summary line per unit of work** |
+| DEBUG | per-item detail: each filter decision, raw response bodies |
+
+**The one rule: no INFO line may be emitted from inside a loop over dataset items.**
+Tally with `src.utils.logging.Tally` and log one summary. Log volume must not grow
+with dataset size; `tests/data/test_data_stage_smoke.py` asserts exactly that by
+running each stage at two input sizes and expecting the same line count.
+
+Turning the volume up:
+
+- `LOG_LEVEL=debug` (or `10`) as an env var. An unreadable value falls back to INFO
+  and says so.
+- The `0_Console` parameter group in the ClearML UI: `log_level` (empty = follow
+  `$LOG_LEVEL`) and `progress` (`auto` | `on` | `off`). At DEBUG, ultralytics' own
+  per-class validation output and per-image predict output come back too.
+
+Two caveats worth knowing before chasing a missing line:
+
+- **`0_Console` only applies from `src/train.py`'s call to `set_log_level()`.**
+  Anything logged earlier — `init_clearml()`, import-time lines in `src/config.py` —
+  follows the env var or the default, whatever the UI says.
+- **`task.execute_remotely()` kills the local process on the next line.** A value set
+  in the UI therefore only ever takes effect on the agent — which is the one console
+  we actually read.
+
+Measuring against the baseline (334 lines of our own output on a 3-epoch, 4-CVAT-task
+run): `grep -cE '\| src\.' console.txt`. The `%(name)s` field in the format string is
+what makes that a one-command check.
+
 ## Code Style
 
 - Python 3.14 required
@@ -130,6 +173,15 @@ YOLO Training
   that runs at module scope in `src/train.py` would re-run per worker — re-initialising
   ClearML and re-downloading datasets. The `if __name__ == "__main__":` guard is what
   prevents that; keep all work inside `main()`.
+- **Quieten ultralytics per call, never with `YOLO_VERBOSE=0`.** The env var is read
+  once in `ultralytics/utils/__init__.py` and drops every ultralytics logger to
+  ERROR — the per-epoch metrics table and the AMP/dataset warnings go with it.
+  `args_val["verbose"]` and `args_predict["model"]["verbose"]` are the right knobs,
+  and `src/train.py` turns them back on at `LOG_LEVEL=DEBUG`.
+- **Console parameters live in `args_console`, not `args_logging`.**
+  `config_clearml()` does `args_train.update(args_logging)` and `args_train` is
+  splatted into `model_yolo.train()`, which rejects unknown keys outright
+  (`SyntaxError: 'log_level' is not a valid YOLO argument`).
 - **`set_base_docker()` replaces the whole container section.** Passing `docker_image`
   without `docker_arguments` drops the `CLEARML_AGENT_SKIP_*` env vars, and the agent
   then ignores the image's baked venv and rebuilds one with pip. Always pass both.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "template-yolov8"
 # Doubles as the training image tag -- see DOCKER_IMAGE in src/params.py. Bump this
 # whenever the image contents change, and never re-tag a published version: existing
 # ClearML tasks pin the tag they were created with.
-version = "0.2.0"
+version = "0.2.1"
 description = "YOLO training template with ClearML tracking and remote execution"
 readme = "README.md"
 # Upper bound is deliberate. torch publishes one cp<minor> wheel set per release;

--- a/ruff.toml
+++ b/ruff.toml
@@ -33,7 +33,10 @@ order-by-type = true
 exclude = [
   "src/migrations/*",
 ]
-extend-select = ["E", "F", "I", "UP", "B", "W", "C90", "N", "D", "PYI", "PT", "RET", "SIM", "ARG", "ERA"]
+# T20 bans print(). The pipeline logs through src/utils/logging.py so that every
+# line carries a level and a module name and can be filtered; a print() is
+# invisible to all of that. Enforced here rather than asked for in prose.
+extend-select = ["E", "F", "I", "UP", "B", "W", "C90", "N", "D", "PYI", "PT", "RET", "SIM", "ARG", "ERA", "T20"]
 ignore = [
   "ANN001",
   "B008",
@@ -56,6 +59,9 @@ unfixable = ["F401"]
 
 
 [lint.per-file-ignores]
+# The print() ban is about pipeline output, which is what runs on an agent and
+# what we have to read afterwards. Test scaffolding can print.
+"tests/**" = ["T20"]
 "src/tests/test_app/test*.py" = ["S101", "PT006", "ARG001"]
 "src/tests/test_app/**/test*.py" = ["S101", "PT006", "ARG001"]
 "conftest.py" = ["S101", "PT006", "ARG001", "F401"]

--- a/src/config.py
+++ b/src/config.py
@@ -3,9 +3,13 @@ import os
 from pydantic import SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
 
 path_to_env = os.path.join(os.getcwd(), ".env")
-print("path_to_env", path_to_env, os.path.exists(path_to_env))
+logger.debug("path_to_env %s exists=%s", path_to_env, os.path.exists(path_to_env))
 
 
 class Settings(BaseSettings):
@@ -27,5 +31,6 @@ settings = Settings()
 settings.CVAT_HOST = settings.CVAT_HOST.replace("\\x3a", ":")
 
 TMP_DIR_CVAT = "./tmp-cvat"
-print("Environment variables loaded successfully.")
-print("CVAT_HOST:", settings.CVAT_HOST)
+# Never log CVAT_HOST: the console of every task is readable to anyone with
+# access to the ClearML project, and this repository is public.
+logger.debug("environment variables loaded successfully")

--- a/src/data/converter/coco2yolo.py
+++ b/src/data/converter/coco2yolo.py
@@ -7,10 +7,11 @@ from uuid import uuid4
 
 import numpy as np
 
-from tqdm import tqdm
-
 from src.schema.coco import Coco as CocoSchema
+from src.utils.logging import get_logger, progress
 
+
+logger = get_logger(__name__)
 
 image_extensions = ["jpg", "jpeg", "png", "gif", "bmp", "tiff", "ico", "webp", "svg"]
 
@@ -151,7 +152,7 @@ class Coco2Yolo:
             exclude_class = []
 
         if os.path.exists(output_dir):
-            print(f"❌ [convert_coco_to_yolo] Remove {output_dir}")
+            logger.debug("removing stale label dir %s", output_dir)
             shutil.rmtree(output_dir)
 
         Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -162,7 +163,7 @@ class Coco2Yolo:
         coco = CocoSchema(**coco_d)
 
         images = coco.get_imageid_to_image()
-        img_to_anns = coco.get_imageid_to_annotations(
+        img_to_anns, _report = coco.get_imageid_to_annotations(
             exclude_class=exclude_class,
             attributes_excluded=attributes_excluded,
             area_segment_min=area_segment_min,
@@ -171,8 +172,8 @@ class Coco2Yolo:
         # write labels in txt file
         cat_id2name = coco.get_categoryid_to_namecat(exclude_class=exclude_class)
 
-        for image_id, img_annotatins in tqdm(
-            img_to_anns.items(), desc="Converting COCO to YOLO"
+        for image_id, img_annotatins in progress(
+            img_to_anns.items(), desc="coco -> yolo labels", logger=logger
         ):
             img = images[image_id]
             h, w, fp_image = img.height, img.width, img.file_name
@@ -231,7 +232,6 @@ class Coco2Yolo:
                         )  # cls, box or segments
                         file.write(("%g " * len(line)).rstrip() % line + "\n")
                     except Exception as e:
-                        print("Error", e)
                         raise Exception(
                             f"ERROR CONVERTER: {txt_file} idx:{i} u"
                             f"se_segments={use_segments} -> {e} >> {bboxes}"
@@ -240,15 +240,17 @@ class Coco2Yolo:
         return list(cat_id2name.values())
 
     def setup_directory(self):
-        print("setup_directory runnnig")
-
         # create new output directry
         self.out_img_dir = os.path.join(self.output_dir, "images")
         self.out_lbl_dir = os.path.join(self.output_dir, "labels")
         Path(self.out_img_dir).mkdir(parents=True, exist_ok=True)
         Path(self.out_lbl_dir).mkdir(parents=True, exist_ok=True)
 
-        print(self.src_img_dir, os.path.exists(self.src_img_dir))
+        logger.debug(
+            "src images %s (exists=%s)",
+            self.src_img_dir,
+            os.path.exists(self.src_img_dir),
+        )
         # copy to new output directory with uuid name
         count_files = 0
 
@@ -257,14 +259,6 @@ class Coco2Yolo:
             self.src_img_dir, extensions=image_extensions
         )
         total_labels = count_files_in_directory(self.src_lbl_yolo, extensions=[".txt"])
-        print(
-            "is_match:",
-            total_images == total_labels,
-            "len images",
-            total_images,
-            "len labels",
-            total_labels,
-        )
 
         count_no_annotations = 0
 
@@ -290,13 +284,18 @@ class Coco2Yolo:
                 else:
                     count_no_annotations += 1
 
-        print(
-            "is_match",
-            count_files == count_no_annotations,
-            "count_files project:",
-            count_files,
-            "count_no_annotations project:",
-            count_no_annotations,
+        # The invariant is that every source image was either copied or skipped
+        # for having no label. The old check compared copied against skipped,
+        # which is not a relationship that means anything.
+        is_match = count_files + count_no_annotations == total_images
+        logger.info(
+            "%s: %s images -> %s copied, %s without labels (labels on disk %s, match=%s)",
+            os.path.basename(self.src_dir.rstrip("/")),
+            f"{total_images:,}",
+            f"{count_files:,}",
+            f"{count_no_annotations:,}",
+            f"{total_labels:,}",
+            is_match,
         )
         return count_files
 
@@ -309,7 +308,6 @@ class Coco2Yolo:
     ):
         if exclude_class is None:
             exclude_class = []
-        print("Start Converting and Filtering COCO to YOLO")
         self.src_lbl_yolo = os.path.join(self.src_dir, "labels")
         list_categories = Coco2Yolo.convert_coco_to_yolo(
             json_path=self.src_lbl_filepath,
@@ -319,20 +317,16 @@ class Coco2Yolo:
             attributes_excluded=attributes_excluded,
             area_segment_min=area_segment_min,
         )
-        print("Setup Directory: Manage Files to structure of YOLO")
         conut_data = self.setup_directory()
-        print("Done Converting and Filtering COCO to YOLO")
         return self.output_dir, list_categories, conut_data
 
 
 if __name__ == "__main__":
-    print("start testing")
     ls_path_dir_projects = ["fyypp-numplate-no-aug", "IOTSmartCampus", "truckplate"]
     ls_path_dir_projects = [
         os.path.join("tmp-cvat/Plate-Detector", path) for path in ls_path_dir_projects
     ]
     if os.path.exists("./testing-debug-ds"):
-        print("❌ Remove testing-debug-ds")
         shutil.rmtree("./testing-debug-ds")
 
     tmp_total_count = 0
@@ -350,8 +344,8 @@ if __name__ == "__main__":
         tmp_total_count += converter.setup_directory()
 
     countfiles_finel = len(os.listdir("./testing-debug-ds/images"))
-    print(
-        "countfiles_finel",
+    logger.info(
+        "countfiles_finel %s vs %s (match=%s)",
         countfiles_finel,
         tmp_total_count,
         tmp_total_count == countfiles_finel,

--- a/src/data/downloader/method/cvat.py
+++ b/src/data/downloader/method/cvat.py
@@ -9,11 +9,35 @@ import requests
 
 from cvat_sdk import make_client
 from requests.auth import HTTPBasicAuth
-from rich import print
-from tqdm import tqdm
 
 from src.config import settings
 from src.data.downloader.base_downloader import BaseDownloader
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+# CVAT builds the export archive asynchronously and answers 202 until it is
+# ready. Without a pause the loop re-asks as fast as the round trip allows,
+# which is both a needless load on the server and an unbounded log.
+POLL_INTERVAL_SECONDS = 2
+POLL_TIMEOUT_SECONDS = 120
+
+# Enough of an error body to recognise the failure, not enough to flood the
+# console -- CVAT answers errors with full HTML pages.
+BODY_PREVIEW_CHARS = 200
+
+STATUS_MESSAGES = {
+    200: "200: Download of file started",
+    201: "201: Output file is ready for downloading",
+    202: "202: Exporting has been started",
+    405: "405: Format is not available",
+}
+
+
+def describe_task_status(response) -> str:
+    """Human-readable form of an export-status response."""
+    return STATUS_MESSAGES.get(response.status_code, f"{response.status_code}: unknown")
 
 
 class CVATHTTPDownloaderV1(BaseDownloader):
@@ -61,26 +85,17 @@ class CVATHTTPDownloaderV1(BaseDownloader):
         return response.json()
 
     @staticmethod
-    def print_task_status(response):
-        status_messages = {
-            200: "200: Download of file started",
-            201: "201: Output file is ready for downloading",
-            202: "202: Exporting has been started",
-            405: "405: Format is not available",
-        }
-        print(status_messages.get(response.status_code, "Unknown status"))
+    def save_file(response, file_name) -> float:
+        """Write the archive to disk and return its size in MB.
 
-    @staticmethod
-    def save_file(response, file_name):
+        No progress bar: `response.content` has already pulled the whole body
+        into memory by the time we get here, so a bar over `iter_content` would
+        be timing a memcpy rather than a download.
+        """
         total_size_mb = round(len(response.content) / 1024000, 2)
-        print("Downloading", file_name)
-        print("TOTAL SIZE: ", total_size_mb, "MB")
         with open(file_name, "wb") as f:
-            for chunk in tqdm(
-                response.iter_content(chunk_size=1024000), total=total_size_mb, ncols=72
-            ):
-                f.write(chunk)
-        print("Downloaded: ", total_size_mb, "MB")
+            f.write(response.content)
+        return total_size_mb
 
     def extract_file(self, file_name, project_info, task_info):
         with zipfile.ZipFile(file_name, "r") as zip_ref:
@@ -89,7 +104,7 @@ class CVATHTTPDownloaderV1(BaseDownloader):
             )
             shutil.rmtree(extract_dir, ignore_errors=True)
             zip_ref.extractall(extract_dir)
-            print("Extracted to:", extract_dir)
+            logger.debug("extracted to %s", extract_dir)
         os.remove(file_name)
         return extract_dir
 
@@ -116,24 +131,23 @@ class CVATHTTPDownloaderV1(BaseDownloader):
                 files=files,
                 params=params,
             )
-            print(
-                response.status_code,
-                text_response.get(response.status_code, response.text),
+            message = text_response.get(
+                response.status_code, response.text[:BODY_PREVIEW_CHARS]
             )
-            if response.status_code != 201 and response.status_code != 202:
-                print(
-                    "[ERROR_UPDATE_CVAT_ANNOTATIONS]",
+            if response.status_code not in (201, 202):
+                logger.error(
+                    "cvat task %s annotation upload failed: %s %s",
+                    task_id,
                     response.status_code,
-                    text_response.get(response.status_code, response.text),
+                    message,
                 )
                 break
 
             response.raise_for_status()
             if response.status_code == 201:
-                print(response.status_code, text_response[response.status_code])
-                # response = requests.get(url=download_url + '&action=download', auth=self.auth, allow_redirects=True)  # noqa: E501, ERA001
-                # self.print_task_status(response)  # noqa: ERA001
+                logger.info("cvat task %s: %s", task_id, message)
                 break
+            logger.debug("cvat task %s upload: %s", task_id, message)
 
     def download(self, task_id: int, annotations_only: bool = False):
         """return: task_info, project_info, file_name_zip."""
@@ -149,48 +163,63 @@ class CVATHTTPDownloaderV1(BaseDownloader):
         try:
             project_info = self.get_project_info(task_info=task_info)
         except Exception as e:
-            print(download_url, e)
+            # Never the URL: it carries CVAT_HOST and this repo is public.
+            logger.error("cvat task %s: cannot read project info: %s", task_id, e)
             raise Exception(
                 f"ERROR taskid: {task_id} | task_info response={task_info}"
             ) from e
 
         timeout_start = time.time()
-        first_exporting_progress = False
+        polls = 0
         while True:
             response = requests.get(
                 url=download_url,
                 auth=self.auth,
             )
-
-            if response.status_code == 202 and first_exporting_progress:
-                first_exporting_progress = True
-                print("🍆", end="\r", flush=True)
-            else:
-                self.print_task_status(response)
+            polls += 1
+            logger.debug(
+                "cvat task %s poll %s: %s", task_id, polls, describe_task_status(response)
+            )
 
             response.raise_for_status()
             if response.status_code == 201:
-                print()
                 response = requests.get(
                     url=download_url + "&action=download",
                     auth=self.auth,
                     allow_redirects=True,
                 )
-                self.print_task_status(response)
+                logger.debug(
+                    "cvat task %s download: %s", task_id, describe_task_status(response)
+                )
                 file_name_zip = f"{self.download_dir}/{task_info['name']}.zip"
-                self.save_file(response, file_name_zip)
+                size_mb = self.save_file(response, file_name_zip)
+                logger.info(
+                    'cvat task %s "%s": ready after %s polls / %.1fs, %s MB',
+                    task_id,
+                    task_info.get("name"),
+                    polls,
+                    time.time() - timeout_start,
+                    size_mb,
+                )
                 break
 
-            if time.time() - timeout_start > 120:
-                print("Timeout Download DATA from CVAT")
-                break
+            if time.time() - timeout_start > POLL_TIMEOUT_SECONDS:
+                # raise, not break: `file_name_zip` is unbound on this path, so
+                # breaking used to surface as an UnboundLocalError below and hide
+                # the timeout entirely.
+                raise TimeoutError(
+                    f"cvat task {task_id}: export not ready after"
+                    f" {POLL_TIMEOUT_SECONDS}s ({polls} polls)"
+                )
+
+            time.sleep(POLL_INTERVAL_SECONDS)
         return task_info, project_info, file_name_zip
 
     def get_local_dataset_coco(self, task_ids: list[int], annotations_only: bool = False):
         """Return: ls_path_dataset = [dataset_dir1, ...)]."""
         ls_path_dataset = []
         for task_id in task_ids:
-            print("Downloading task_id: ", task_id, " ...")
+            logger.debug("downloading cvat task %s", task_id)
             task_info, project_info, file_name_zip = self.download(
                 task_id, annotations_only=annotations_only
             )
@@ -251,24 +280,12 @@ class CVATHTTPDownloaderV2(BaseDownloader):
         return response.json()
 
     @staticmethod
-    def print_task_status(response):
-        status_messages = {
-            200: "200: Download of file started",
-            201: "201: Output file is ready for downloading",
-            202: "202: Exporting has been started",
-            405: "405: Format is not available",
-        }
-        print(status_messages.get(response.status_code, "Unknown status"))
-
-    @staticmethod
-    def save_file(response, file_name):
+    def save_file(response, file_name) -> float:
+        """Write the archive to disk and return its size in MB."""
         total_size_mb = round(len(response.content) / 1024000, 2)
-        print("Downloading", file_name, " | SIZE: ", total_size_mb, "MB")
         with open(file_name, "wb") as f:
-            for chunk in tqdm(
-                response.iter_content(chunk_size=1024000), total=total_size_mb, ncols=72
-            ):
-                f.write(chunk)
+            f.write(response.content)
+        return total_size_mb
 
     def extract_file(self, file_name, project_info, task_info):
         with zipfile.ZipFile(file_name, "r") as zip_ref:
@@ -277,7 +294,7 @@ class CVATHTTPDownloaderV2(BaseDownloader):
             )
             shutil.rmtree(extract_dir, ignore_errors=True)
             zip_ref.extractall(extract_dir)
-            print("Extracted to:", extract_dir)
+            logger.debug("extracted to %s", extract_dir)
         os.remove(file_name)
         return extract_dir
 
@@ -304,24 +321,23 @@ class CVATHTTPDownloaderV2(BaseDownloader):
                 files=files,
                 params=params,
             )
-            print(
-                response.status_code,
-                text_response.get(response.status_code, response.text),
+            message = text_response.get(
+                response.status_code, response.text[:BODY_PREVIEW_CHARS]
             )
-            if response.status_code != 201 and response.status_code != 202:
-                print(
-                    "[ERROR_UPDATE_CVAT_ANNOTATIONS]",
+            if response.status_code not in (201, 202):
+                logger.error(
+                    "cvat task %s annotation upload failed: %s %s",
+                    task_id,
                     response.status_code,
-                    text_response.get(response.status_code, response.text),
+                    message,
                 )
                 break
 
             response.raise_for_status()
             if response.status_code == 201:
-                print(response.status_code, text_response[response.status_code])
-                # response = requests.get(url=download_url + '&action=download', auth=self.auth, allow_redirects=True)  # noqa: E501, ERA001
-                # self.print_task_status(response)  # noqa: ERA001
+                logger.info("cvat task %s: %s", task_id, message)
                 break
+            logger.debug("cvat task %s upload: %s", task_id, message)
 
     def download(self, task_id: int, annotations_only: bool = False):
         """return: task_info, project_info, file_name_zip."""
@@ -337,41 +353,53 @@ class CVATHTTPDownloaderV2(BaseDownloader):
         project_info = self.get_project_info(task_info=task_info)
 
         timeout_start = time.time()
-        first_exporting_progress = False
+        polls = 0
         while True:
             response = requests.get(
                 url=download_url, auth=self.auth, params={"org": self.organization}
             )
-
-            if response.status_code == 202 and first_exporting_progress:
-                first_exporting_progress = True
-                print("🍆", end="\r", flush=True)
-            else:
-                self.print_task_status(response)
+            polls += 1
+            logger.debug(
+                "cvat task %s poll %s: %s", task_id, polls, describe_task_status(response)
+            )
 
             response.raise_for_status()
             if response.status_code == 201:
-                print()
                 response = requests.get(
                     url=download_url + "&action=download",
                     auth=self.auth,
                     allow_redirects=True,
                 )
-                self.print_task_status(response)
+                logger.debug(
+                    "cvat task %s download: %s", task_id, describe_task_status(response)
+                )
                 file_name_zip = f"{self.download_dir}/{task_info['name']}.zip"
-                self.save_file(response, file_name_zip)
+                size_mb = self.save_file(response, file_name_zip)
+                logger.info(
+                    'cvat task %s "%s": ready after %s polls / %.1fs, %s MB',
+                    task_id,
+                    task_info.get("name"),
+                    polls,
+                    time.time() - timeout_start,
+                    size_mb,
+                )
                 break
 
-            if time.time() - timeout_start > 120:
-                print("Timeout Download DATA from CVAT")
-                break
+            if time.time() - timeout_start > POLL_TIMEOUT_SECONDS:
+                # raise, not break -- see the note on the V1 downloader.
+                raise TimeoutError(
+                    f"cvat task {task_id}: export not ready after"
+                    f" {POLL_TIMEOUT_SECONDS}s ({polls} polls)"
+                )
+
+            time.sleep(POLL_INTERVAL_SECONDS)
         return task_info, project_info, file_name_zip
 
     def get_local_dataset_coco(self, task_ids: list[int], annotations_only: bool = False):
         """return: ls_path_dataset = [dataset_dir1, ...)]."""
         ls_path_dataset = []
         for task_id in task_ids:
-            print("Downloading task_id: ", task_id, " ...")
+            logger.debug("downloading cvat task %s", task_id)
             task_info, project_info, file_name_zip = self.download(
                 task_id, annotations_only=annotations_only
             )
@@ -421,11 +449,17 @@ class CVATSDKDownloader(BaseDownloader):
             export_path = os.path.join(self.download_dir, filename_zip)
             if os.path.exists(export_path):
                 os.remove(export_path)
-            print("exporting...")
+            started = time.time()
             task.export_dataset(
                 include_images=True, format_name="COCO 1.0", filename=export_path
             )
-            print("exported")
+            logger.info(
+                'cvat task %s "%s": exported in %.1fs, %s MB',
+                task_id,
+                task.name,
+                time.time() - started,
+                round(os.path.getsize(export_path) / 1024000, 2),
+            )
 
             os.makedirs(self.download_dir, exist_ok=True)
             with zipfile.ZipFile(export_path, "r") as zip_ref:

--- a/src/data/downloader/method/minio_dir.py
+++ b/src/data/downloader/method/minio_dir.py
@@ -5,6 +5,11 @@ from concurrent.futures import ThreadPoolExecutor
 
 from minio import Minio
 
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
 
 class MinioDatasetDownloader:
     def __init__(self):
@@ -45,7 +50,6 @@ class MinioDatasetDownloader:
 
         ls_class = set()
         # Iterate over the classes in the dataset
-        print("\t⚡ Downloading dataset")
         time_start = time.time()
         for class_name, urls in dataset_dict.items():
             # Create the class directory if it doesn't exist
@@ -75,7 +79,12 @@ class MinioDatasetDownloader:
                         destination_path,
                     )
         duration = round(time.time() - time_start, 2)
-        print(f"\t✅ Completed download dataset in {duration} secs!")
+        logger.info(
+            "minio: %d classes, %d files in %ss",
+            len(ls_class),
+            sum(len(urls) for urls in dataset_dict.values()),
+            duration,
+        )
         return ls_class
 
 

--- a/src/data/downloader/method/s3_dir.py
+++ b/src/data/downloader/method/s3_dir.py
@@ -11,8 +11,12 @@ import boto3.session
 import splitfolders
 
 from clearml import config as config_clearml
-
 from data.utils import mkdir_p
+
+from src.utils.logging import Tally, get_logger
+
+
+logger = get_logger(__name__)
 
 
 def download_object(s3_client, url_s3, save_dir):
@@ -35,7 +39,7 @@ def download_files_from_s3_multithreading(s3_paths, aws_access_key_id, aws_secre
 
     # Dispatch work tasks with our s3_client
     mkdir_p(save_dir)
-    print('start')
+    logger.debug("downloading %d objects to %s", len(s3_paths), save_dir)
     with ThreadPoolExecutor(max_workers=10) as executor:
         future_to_key = {executor.submit(download_object, s3_client, url_s3, save_dir): url_s3 for url_s3 in s3_paths}
 
@@ -84,7 +88,7 @@ class HandlerS3:
 
         # Dispatch work tasks with our s3_client
         mkdir_p(self.tmp_dir)
-        print('start')
+        logger.debug("downloading %d objects to %s", len(s3_paths), self.tmp_dir)
         with ThreadPoolExecutor(max_workers=8) as executor:
             future_to_key = {executor.submit(self.download_object, s3_client, url_s3): url_s3 for url_s3 in s3_paths}
 
@@ -100,7 +104,7 @@ class HandlerS3:
     def extract_list(self, dir_s3_path:str):
         bucket_name = dir_s3_path.replace('s3://', '').split('/')[0]
         prefix = dir_s3_path.replace(f's3://{bucket_name}/', '')
-        print(bucket_name, prefix)
+        logger.debug("listing bucket=%s prefix=%s", bucket_name, prefix)
         s3_client = boto3.client('s3',
                             aws_access_key_id=self.aws_access_key_id,
                             aws_secret_access_key=self.aws_secret_access_key
@@ -116,9 +120,10 @@ class HandlerS3:
         # download from s3
         s3_paths = self.extract_list(dir_s3_path)
         start_time = time.time()
+        failures = Tally()
         for key, result in self.download_files_from_s3_multithreading(s3_paths):
             if result != True:
-                print('FAILED:', key, result)
+                failures.add("download failed", key)
         end_time = time.time() - start_time
 
         # splitting
@@ -132,13 +137,20 @@ class HandlerS3:
 
         # write yaml for yolo
         cls_names = os.listdir(os.path.join(self.output_dir, 'train'))
-        print(cls_names)
         with open(os.path.join(self.output_dir, 'data.yaml'), 'w') as f:
             f.write("train: train/\n")
             f.write("val: val/\n")
             f.write(f"nc: {len(cls_names)}\n")
             f.write(f"names: {cls_names}\n")
-        print(f'Done Download in {round(end_time, 3)} secs for {len(s3_paths)} images')
+        logger.info(
+            "s3: %d images in %.1fs, %d classes%s",
+            len(s3_paths),
+            end_time,
+            len(cls_names),
+            f"; {failures.total()} failed [{failures.summary(with_examples=True)}]"
+            if failures
+            else "",
+        )
         return self.output_dir
 
 if __name__ == '__main__':

--- a/src/data/setup.py
+++ b/src/data/setup.py
@@ -4,7 +4,26 @@ import shutil
 
 from pathlib import Path
 
-from tqdm import tqdm
+from src.utils.logging import get_logger, progress
+
+
+logger = get_logger(__name__)
+
+# How many filenames to show when a split fails its checks. Enough to recognise
+# the problem, not the whole listing -- these directories hold thousands.
+MAX_EXAMPLE_FILES = 5
+
+
+def _sample(dir_path: str) -> str:
+    """Return a few filenames from `dir_path`, for error messages."""
+    try:
+        names = sorted(os.listdir(dir_path))
+    except OSError:
+        return "<unreadable>"
+    shown = ", ".join(names[:MAX_EXAMPLE_FILES]) or "<empty>"
+    if len(names) > MAX_EXAMPLE_FILES:
+        shown += f", ... (+{len(names) - MAX_EXAMPLE_FILES})"
+    return shown
 
 
 def creating_yaml_file(source_dir, labels: list = None):
@@ -16,8 +35,7 @@ def creating_yaml_file(source_dir, labels: list = None):
     if labels is None:
         fp_label_txt = os.path.join(source_dir, "classes.txt")
         if not os.path.exists(fp_label_txt):
-            print(f"yaml_path: {fp_label_txt}")
-            raise Exception("[Creating YAML] classes.txt not found")
+            raise Exception(f"[Creating YAML] classes.txt not found: {fp_label_txt}")
         with open(fp_label_txt) as f:
             labels = f.readlines()
             labels = [line.strip() for line in labels]
@@ -37,35 +55,37 @@ def creating_yaml_file(source_dir, labels: list = None):
 
         # checkhing
         is_dir_exist = os.path.exists(dir_img) and os.path.exists(dir_labels)
-        is_have_files = len(os.listdir(dir_img)) > 0 and len(os.listdir(dir_labels)) > 0
-        is_exact_count = len(os.listdir(dir_img)) == len(os.listdir(dir_labels))
+        count_img = len(os.listdir(dir_img)) if is_dir_exist else 0
+        count_labels = len(os.listdir(dir_labels)) if is_dir_exist else 0
+        is_have_files = count_img > 0 and count_labels > 0
+        is_exact_count = count_img == count_labels
 
         is_passed = is_dir_exist and is_have_files and is_exact_count
 
         if dir == "test":
             if is_passed:
                 use_test = True
-        else:
-            if not is_passed:
-                print
-                print(f"yaml_path: {out_fp_yaml}")
-                print(f"""
-                {dir_img}
-                {dir_labels}
-                {os.listdir(dir_img)}
-                {os.listdir(dir_labels)}
-                      
-                is_dir_exist:{is_dir_exist}
-                is_have_files:{is_have_files}
-                is_exact_count:{is_exact_count}
-
-
-                """)
-                raise Exception(f"""[Creating YAML] {dir} folder is not valid. 
-                                is_dir_exist:{is_dir_exist}
-                                is_have_files:{is_have_files}
-                                is_exact_count:{is_exact_count}
-                                """)
+        elif not is_passed:
+            # Counts and a handful of names. The previous version interpolated
+            # two full os.listdir() results into one f-string.
+            logger.error(
+                'split "%s" invalid: images=%d labels=%d'
+                " (dir_exist=%s non_empty=%s counts_match=%s); images: %s; labels: %s",
+                dir,
+                count_img,
+                count_labels,
+                is_dir_exist,
+                is_have_files,
+                is_exact_count,
+                _sample(dir_img),
+                _sample(dir_labels),
+            )
+            raise Exception(
+                f"[Creating YAML] {dir} folder is not valid."
+                f" images={count_img} labels={count_labels}"
+                f" is_dir_exist={is_dir_exist} is_have_files={is_have_files}"
+                f" is_exact_count={is_exact_count}"
+            )
 
     with open(out_fp_yaml, "w") as f:
         f.write("train: train/images\n")
@@ -74,6 +94,11 @@ def creating_yaml_file(source_dir, labels: list = None):
             f.write("test: test/images\n\n")
         f.write(f"nc: {len(labels)}\n")
         f.write(f"names: {[name for name in labels]}")
+    logger.info(
+        "data.yaml: %d classes, splits %s",
+        len(labels),
+        "/".join(["train", "valid", *(["test"] if use_test else [])]),
+    )
     return out_fp_yaml
 
 
@@ -142,21 +167,35 @@ def split_folder_yolo(source_dir, train_ratio=0.8, valid_ratio=0.2, test_ratio=N
         ls_files.append(ls_test)
 
     # Copy images and labels to the corresponding sets
-    for list_files, dst_dir in zip(ls_files, ls_dirs, strict=False):
-        for src_fp_image, src_fp_label in tqdm(list_files, desc="Splitting files"):
-            dst_fp_image = os.path.join(dst_dir, "images", os.path.basename(src_fp_image))
-            dst_fp_label = os.path.join(dst_dir, "labels", os.path.basename(src_fp_label))
-            shutil.move(src_fp_image, dst_fp_image)
-            shutil.move(src_fp_label, dst_fp_label)
+    moves = [
+        (src_fp_image, src_fp_label, dst_dir)
+        for list_files, dst_dir in zip(ls_files, ls_dirs, strict=False)
+        for src_fp_image, src_fp_label in list_files
+    ]
+    for src_fp_image, src_fp_label, dst_dir in progress(
+        moves, desc="splitting files", logger=logger
+    ):
+        dst_fp_image = os.path.join(dst_dir, "images", os.path.basename(src_fp_image))
+        dst_fp_label = os.path.join(dst_dir, "labels", os.path.basename(src_fp_label))
+        shutil.move(src_fp_image, dst_fp_image)
+        shutil.move(src_fp_label, dst_fp_label)
 
     shutil.rmtree(src_dir_images)
     shutil.rmtree(src_dir_labels)
 
+    logger.info(
+        "split: %s pairs -> %s",
+        f"{total_files:,}",
+        " / ".join(
+            f"{os.path.basename(d)} {len(files):,}"
+            for files, d in zip(ls_files, ls_dirs, strict=False)
+        ),
+    )
+
 
 def creating_classes_txt(dataset_dir, label_names):
     with open(os.path.join(dataset_dir, "classes.txt"), "w") as file:
-        for cls_name in label_names:
-            file.write(cls_name + "\n")
+        file.writelines(cls_name + "\n" for cls_name in label_names)
 
 
 def setup_dataset(
@@ -200,7 +239,7 @@ def cleanup_cache(dataset_dir):
     for section in ["train", "valid", "test"]:
         path_cache = os.path.join(dataset_dir, section, "labels.cache")
         if os.path.exists(path_cache):
-            print(f"Removing {path_cache}")
+            logger.debug("removing %s", path_cache)
             os.remove(path_cache)
 
 

--- a/src/initizalization.py
+++ b/src/initizalization.py
@@ -1,10 +1,14 @@
-from rich import print
 from ultralytics import settings
+
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def init_ultralytics_settings():
     """Initialize YOLO settings for ClearML integration."""
-    # Disable ClearML integration in Ultralytics settings
-    print("ClearML integration disabled in Ultralytics settings.")
+    # Disable ClearML integration in Ultralytics settings; we log it ourselves
+    # from src/yolov8/callbacks.py.
     settings.update({"clearml": False})
-    print("Settings Ultralytics ClearML:", settings["clearml"])
+    logger.debug("ultralytics clearml integration: %s", settings["clearml"])

--- a/src/params.py
+++ b/src/params.py
@@ -14,7 +14,7 @@ import os
 #
 # TRAINER_IMAGE overrides it -- point it at a registry path to run agents off a
 # pushed image, e.g. TRAINER_IMAGE=ghcr.io/acme/yolo-trainer:0.2.0.
-DOCKER_IMAGE = os.getenv("TRAINER_IMAGE", "yolo-trainer:0.2.0")
+DOCKER_IMAGE = os.getenv("TRAINER_IMAGE", "yolo-trainer:0.2.1")
 
 # Passed to every containerised run. The two SKIP_* flags are what make the image's
 # baked venv authoritative: without them the agent ignores /workspace/.venv and
@@ -77,6 +77,18 @@ args_export = {
 args_logging = {
     "project": "YOLO/Training",
     "name": "training-yolo",
+}
+
+# Console verbosity. A dict of its own on purpose: config_clearml() does
+# `args_train.update(args_logging)` and passes args_train straight to
+# model_yolo.train(), where ultralytics rejects unknown keys --
+# "SyntaxError: 'log_level' is not a valid YOLO argument" would break every run.
+#
+# Only takes effect from the point train.py applies it, so anything logged
+# before that (init_clearml, imports) still follows $LOG_LEVEL / the default.
+args_console = {
+    "log_level": "",  # empty = follow $LOG_LEVEL, which defaults to INFO
+    "progress": "auto",  # auto (bars on a TTY only) | on | off
 }
 
 args_task = {
@@ -174,6 +186,9 @@ args_val = {
     "rect": False,  # rectangular val with each batch collated for minimum padding
     "save_crop": True,  # save cropped images
     "split": "val",  # dataset split to use for validation, i.e. 'val', 'test' or 'train'
+    # One console line per class from models/yolo/detect/val.py; the same numbers
+    # are logged to ClearML as a per-class table. Re-enabled at LOG_LEVEL=DEBUG.
+    "verbose": False,
 }
 
 
@@ -196,6 +211,12 @@ args_predict = {
         "iou": 0.7,  # intersection over union (IoU) threshold for NMS
         "max_det": 1000,  # maximum number of detections per image
         "stream": True,  # stream mode for real-time inference
+        # One line per image from ultralytics/engine/predictor.py -- 40 of them,
+        # the single biggest block of noise in the run. Re-enabled at DEBUG.
+        # Note this is per-call verbose, not YOLO_VERBOSE=0: the env var drops
+        # every ultralytics logger to ERROR and would take the per-epoch metric
+        # table and the AMP/dataset warnings with it.
+        "verbose": False,
     },
 }
 

--- a/src/schema/coco.py
+++ b/src/schema/coco.py
@@ -1,6 +1,39 @@
 from collections import defaultdict
+from dataclasses import dataclass, field
 
 from pydantic import BaseModel
+
+from src.utils.logging import Tally, get_logger
+
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class FilterReport:
+    """What annotation filtering did, as counts rather than as a line per item."""
+
+    total: int = 0
+    kept: int = 0
+    dropped_area: int = 0
+    dropped_class: Tally = field(default_factory=Tally)
+    dropped_attr: Tally = field(default_factory=Tally)
+
+    @property
+    def dropped(self) -> int:
+        return self.total - self.kept
+
+    def reasons(self, area_segment_min: float | None = None) -> str:
+        parts = []
+        if self.dropped_class:
+            parts.append(
+                f"class {self.dropped_class.total():,} [{self.dropped_class.summary()}]"
+            )
+        if self.dropped_area:
+            parts.append(f"area<{area_segment_min} = {self.dropped_area:,}")
+        if self.dropped_attr:
+            parts.append(f"attr {self.dropped_attr.summary()}")
+        return ", ".join(parts)
 
 
 class License(BaseModel):
@@ -56,7 +89,7 @@ class Coco(BaseModel):
     def get_categoryid_to_namecat(
         self,
         exclude_class: list[str] = None,  # noqa: ARG002
-    ) -> dict[int, str]:  # noqa: ARG002
+    ) -> dict[int, str]:
         categories_map = {}
         # exclude_class  = [lbl.lower() for lbl in exclude_class]  # noqa: ERA001
         # if len(exclude_class) > 0:
@@ -78,31 +111,31 @@ class Coco(BaseModel):
         exclude_class: list[str] = None,
         attributes_excluded: dict[str, str] = None,
         area_segment_min: float = None,
-    ) -> dict[int, list[Annotation]]:
-        """Return a dictionary of image_id to annotations.
+    ) -> tuple[dict[int, list[Annotation]], FilterReport]:
+        """Return image_id -> annotations, plus a report of what was filtered out.
 
-        Filters are applied at the annotation level.
+        Filters are applied at the annotation level. The per-annotation decisions
+        are tallied and logged as one INFO line; individual decisions go to DEBUG,
+        because there is one per annotation and a dataset has tens of thousands.
         """
-        if exclude_class is None:
-            exclude_class = []
         if exclude_class is None:
             exclude_class = []
 
         imageid2anns = defaultdict(list)
         exclude_class = [lbl.lower() for lbl in exclude_class]
         id2label = self.get_categoryid_to_namecat()
-        print(id2label)
+        logger.debug("categories: %s", id2label)
 
-        for ann in self.annotations:
+        report = FilterReport(total=len(self.annotations or []))
+
+        for ann in self.annotations or []:
             skip = False
-            if area_segment_min is not None:  # noqa: SIM102
-                if ann.area < area_segment_min:
-                    print(
-                        f"[Area Filters Active] minimal: {area_segment_min} | actual:",
-                        ann.area,
-                    )
-                    skip = True
-                    continue
+            if area_segment_min is not None and ann.area < area_segment_min:
+                logger.debug(
+                    "ann %s dropped: area %s < %s", ann.id, ann.area, area_segment_min
+                )
+                report.dropped_area += 1
+                continue
 
             if attributes_excluded is not None:
                 for attr_name, attr_value in attributes_excluded.items():
@@ -118,35 +151,47 @@ class Coco(BaseModel):
                     if attributes_dataset is None:
                         continue
 
-                    # print("attributes_excluded", attributes_excluded, ann.attributes)  # noqa: E501, ERA001
                     if isinstance(attributes_dataset, set):
                         intersection = attributes_config.intersection(attributes_dataset)
                         if intersection:
-                            print(
-                                "[Attributes Filters Active]",
+                            logger.debug(
+                                "ann %s dropped: attribute %s in %s",
+                                ann.id,
                                 attr_name,
-                                attributes_config,
-                                attributes_dataset,
+                                sorted(intersection),
                             )
+                            report.dropped_attr.add(attr_name, ann.id)
                             skip = True
                             break
                         break
 
             if id2label[ann.category_id] in exclude_class:
-                print("[Class Filters]", id2label[ann.category_id], "Class Exclude")
+                logger.debug(
+                    "ann %s dropped: class %s excluded", ann.id, id2label[ann.category_id]
+                )
+                report.dropped_class.add(id2label[ann.category_id], ann.id)
                 skip = True
 
             if skip:
                 continue
 
+            report.kept += 1
             imageid2anns[ann.image_id].append(ann)
 
-        return imageid2anns
+        reasons = report.reasons(area_segment_min)
+        logger.info(
+            "annotations: %s total -> %s kept, %s dropped%s",
+            f"{report.total:,}",
+            f"{report.kept:,}",
+            f"{report.dropped:,}",
+            f" ({reasons})" if reasons else "",
+        )
+        return imageid2anns, report
 
     def checking_task(self):
         task_type = set()
         if len(self.annotations) == 0:
-            print("No annotations")
+            logger.warning("no annotations in this COCO file")
             return list(task_type)
 
         for ann in self.annotations:

--- a/src/train.py
+++ b/src/train.py
@@ -1,4 +1,5 @@
 import glob
+import logging
 import os
 import random
 
@@ -12,9 +13,10 @@ from ultralytics import YOLO
 from src.config import settings  # noqa: F401
 from src.data.setup import cleanup_cache
 from src.initizalization import init_ultralytics_settings
+from src.params import args_console
 from src.utils.clearml_settings import config_clearml, init_clearml
 from src.utils.general import get_task_yolo_name, model_name_handler, yaml_loader
-from src.utils.logging import get_logger
+from src.utils.logging import get_logger, resolve_level, set_log_level, set_progress_mode
 from src.yolov8.callbacks import callbacks
 from src.yolov8.clearml_logger import YOLOClearMLLogger
 from src.yolov8.data import DataHandler
@@ -23,6 +25,18 @@ from src.yolov8.metrics_utils import collect_prediction_confidences
 
 
 logger = get_logger(__name__)
+
+
+def _apply_console_verbosity(args_val: dict, args_predict: dict) -> None:
+    """Hand ultralytics' own per-item output back at DEBUG.
+
+    Both defaults are `verbose: False` -- roughly 50 lines of per-class val
+    output and per-image predict output whose content is already in ClearML.
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    args_val["verbose"] = True
+    args_predict["model"]["verbose"] = True
 
 
 def _tagging_handler(task: Task, task_yolo: str, model_name: str, handler: DataHandler):
@@ -88,8 +102,9 @@ def _predicting_result(
         return
 
     logger.info(
-        "image_paths: %s, exists: %s", image_paths[0:5], os.path.exists(image_paths[0])
+        "predicting on %d images from %s", len(image_paths), os.path.basename(path_test)
     )
+    logger.debug("image_paths: %s", image_paths[0:5])
 
     # Get class names for confidence logging
     class_names = datadotyaml.get("names", [])
@@ -198,6 +213,14 @@ def main():
         args_visualization,
     ) = config_clearml()
 
+    # From here on the ClearML UI wins over $LOG_LEVEL. Everything logged above --
+    # init_clearml(), imports -- only ever follows the env var. And because
+    # execute_remotely() kills the local process on the next line, a value set in
+    # the UI only ever takes effect on the agent, which is the console that matters.
+    set_log_level(resolve_level(args_console["log_level"] or None))
+    set_progress_mode(args_console["progress"])
+    _apply_console_verbosity(args_val, args_predict)
+
     task.execute_remotely()
 
     # Set Task Name
@@ -217,7 +240,12 @@ def main():
     datadotyaml = yaml_loader(data_yaml_file)
     class_2_idx = {cls_name: idx for idx, cls_name in enumerate(datadotyaml["names"])}
     task.set_model_label_enumeration(class_2_idx)
-    logger.info("datadotyaml: %s, class_2_idx: %s", datadotyaml, class_2_idx)
+    logger.info(
+        "data.yaml: %d classes, splits %s",
+        len(class_2_idx),
+        "/".join(k for k in ("train", "val", "test") if datadotyaml.get(k)),
+    )
+    logger.debug("datadotyaml: %s, class_2_idx: %s", datadotyaml, class_2_idx)
 
     logger.info("[Training]")
     logger.info("LOAD MODEL: %s, task: %s", model_name, task_yolo)

--- a/src/utils/clearml_settings.py
+++ b/src/utils/clearml_settings.py
@@ -6,6 +6,7 @@ from src.params import (
     DOCKER_ARGUMENTS,
     DOCKER_IMAGE,
     args_augment,
+    args_console,
     args_data,
     args_export,
     args_logging,
@@ -68,6 +69,7 @@ def config_clearml():
     This function will be called in the main function of train.py
     """  # noqa: D205
     curr_task: Task = Task.current_task()
+    curr_task.connect(args_console, name="0_Console")
     curr_task.connect(args_task, name="1_Task")
     curr_task.connect(args_data, name="2_Data")
     curr_task.connect(args_augment, name="3_Augment")

--- a/src/utils/general.py
+++ b/src/utils/general.py
@@ -9,6 +9,11 @@ import yaml
 from clearml import Task
 from yaml.loader import SafeLoader
 
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
 
 def get_task_yolo_name(arg_model_name) -> Literal["segment", "detect", "classify"]:
     task_yolo = "None"
@@ -34,7 +39,7 @@ def model_name_handler(arg_model_name):
         new_path_model_yaml = os.path.join(os.getcwd(), f"src/yolov8/{arg_model_name}")
         shutil.copy(default_path_model_yaml, new_path_model_yaml)
 
-        print("config_file", default_path_model_yaml, new_path_model_yaml)
+        logger.debug("config_file %s -> %s", default_path_model_yaml, new_path_model_yaml)
         return new_path_model_yaml
     new_model_name = arg_model_name + ".pt"
     return new_model_name

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -1,11 +1,165 @@
-"""Logging configuration for the training pipeline."""
+"""Logging configuration for the training pipeline.
+
+Deliberately free of project imports. `src/config.py` builds a pydantic
+`Settings` with six required fields and raises at import time when any of them
+is missing, so reading the log level through it would make logging unusable in
+exactly the runs that need it most. The level is read straight from
+`os.environ`.
+
+One handler is attached to the `src` logger and `propagate` is turned off.
+ClearML calls `logging.basicConfig()` on the root logger from
+`clearml/backend_interface/task/log.py`, which would make every line of ours
+appear twice if we propagated.
+"""
 
 import logging
+import os
 import sys
+import time
+
+from collections import Counter
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from typing import Any
+
+
+ROOT_LOGGER_NAME = "src"
+LOG_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+DEFAULT_LEVEL = logging.INFO
+ENV_VAR = "LOG_LEVEL"
+_HANDLER_NAME = "src-console"
+PROGRESS_MODES = ("auto", "on", "off")
+
+_configured = False
+_progress_mode = "auto"
+# Values already complained about. get_logger() runs setup_logging() on every
+# call, so without this a single unreadable LOG_LEVEL warns once per module.
+_warned_values: set[str] = set()
+
+
+def _parse_level(value: Any) -> int | None:
+    """Turn a level name, a numeric string or an int into a logging level.
+
+    Returns None when `value` carries no level -- either because it is empty
+    (meaning "not set", not "invalid") or because it is unreadable. Callers
+    distinguish the two.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.isdigit():
+        return int(text)
+    return logging.getLevelNamesMapping().get(text.upper())
+
+
+def _is_blank(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and not value.strip())
+
+
+def resolve_level(explicit: Any = None) -> int:
+    """Resolve the effective log level: explicit > $LOG_LEVEL > INFO.
+
+    An unreadable value falls back to INFO *and* warns. A silent fallback means
+    debugging a run that quietly ignored the flag you set.
+    """
+    for source, raw in (
+        ("explicit value", explicit),
+        (f"${ENV_VAR}", os.environ.get(ENV_VAR)),
+    ):
+        if _is_blank(raw):
+            continue
+        level = _parse_level(raw)
+        if level is not None:
+            return level
+        if f"{source}={raw!r}" not in _warned_values:
+            _warned_values.add(f"{source}={raw!r}")
+            logging.getLogger(f"{ROOT_LOGGER_NAME}.utils.logging").warning(
+                "unreadable log level from %s: %r -- falling back to INFO", source, raw
+            )
+        return DEFAULT_LEVEL
+    return DEFAULT_LEVEL
+
+
+def setup_logging(level: Any = None) -> None:
+    """Install the single `src` handler. Idempotent; safe to call from anywhere.
+
+    Only the first call (or one that names a level) decides the level, so the
+    `get_logger()` in every module does not keep re-reading the environment and
+    undoing a later `set_log_level()`.
+    """
+    global _configured
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    already_configured = _configured
+    if not _configured:
+        handler = logging.StreamHandler(sys.stdout)
+        handler.set_name(_HANDLER_NAME)
+        handler.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=DATE_FORMAT))
+        root.handlers = [h for h in root.handlers if h.get_name() != _HANDLER_NAME]
+        root.addHandler(handler)
+        # Not negotiable: ClearML's basicConfig() on the root logger would
+        # otherwise duplicate every line we emit.
+        root.propagate = False
+        root.setLevel(DEFAULT_LEVEL)
+        _configured = True
+
+    if not already_configured or not _is_blank(level):
+        root.setLevel(resolve_level(level))
+
+
+def set_log_level(level: Any) -> None:
+    """Re-point the level after startup, e.g. once ClearML params are connected."""
+    setup_logging()
+    parsed = _parse_level(level)
+    logging.getLogger(ROOT_LOGGER_NAME).setLevel(
+        DEFAULT_LEVEL if parsed is None else parsed
+    )
+
+
+def set_progress_mode(mode: str | None) -> None:
+    """Choose whether `progress()` draws bars: auto (TTY only), on, or off."""
+    global _progress_mode
+
+    normalized = (mode or "auto").strip().lower()
+    if normalized not in PROGRESS_MODES:
+        get_logger(__name__).warning(
+            "unknown progress mode %r -- using 'auto' (one of %s)",
+            mode,
+            ", ".join(PROGRESS_MODES),
+        )
+        normalized = "auto"
+    _progress_mode = normalized
+
+
+def _main_module_name() -> str:
+    """Best-effort module name for a script started as `__main__`."""
+    main = sys.modules.get("__main__")
+    path = getattr(main, "__file__", None)
+    return Path(path).stem if path else "main"
+
+
+def _normalize(name: str) -> str:
+    """Map any logger name into the `src.` tree.
+
+    `make run` executes src/train.py as a script, so `__name__` there is
+    `__main__` -- without this its sixteen log lines would sit outside the tree
+    the handler is attached to and stay unconfigured.
+    """
+    if name == ROOT_LOGGER_NAME or name.startswith(f"{ROOT_LOGGER_NAME}."):
+        return name
+    if name in {"__main__", "__mp_main__"}:
+        name = _main_module_name()
+    return f"{ROOT_LOGGER_NAME}.{name}"
 
 
 def get_logger(name: str) -> logging.Logger:
-    """Get a configured logger instance.
+    """Get a logger inside the configured `src` tree.
 
     Args:
         name: The logger name, typically __name__.
@@ -14,17 +168,85 @@ def get_logger(name: str) -> logging.Logger:
         Configured logger instance.
 
     """
-    logger = logging.getLogger(name)
+    setup_logging()
+    return logging.getLogger(_normalize(name))
 
-    if not logger.handlers:
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(
-            logging.Formatter(
-                "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
-                datefmt="%Y-%m-%d %H:%M:%S",
-            )
-        )
-        logger.addHandler(handler)
-        logger.setLevel(logging.INFO)
 
-    return logger
+def is_tty() -> bool:
+    """Whether stdout is a terminal. Evaluated per call, never cached at import."""
+    try:
+        return bool(sys.stdout.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
+class Tally:
+    """Count occurrences per key, keeping the first few examples of each.
+
+    The shape every per-item loop in the data stage collapses into: instead of
+    one line per annotation or per file, the loop tallies and the caller emits a
+    single summary. Line count then stops tracking dataset size.
+    """
+
+    def __init__(self, max_examples: int = 3) -> None:
+        self.counts: Counter[str] = Counter()
+        self.examples: dict[str, list[str]] = {}
+        self.max_examples = max_examples
+
+    def add(self, key: str, example: Any = None) -> None:
+        self.counts[key] += 1
+        if example is not None:
+            seen = self.examples.setdefault(key, [])
+            if len(seen) < self.max_examples:
+                seen.append(str(example))
+
+    def total(self) -> int:
+        return sum(self.counts.values())
+
+    def __bool__(self) -> bool:
+        return bool(self.counts)
+
+    def __len__(self) -> int:
+        return len(self.counts)
+
+    def __getitem__(self, key: str) -> int:
+        return self.counts[key]
+
+    def summary(self, with_examples: bool = False) -> str:
+        """`stalk 300, foreign_object 212`, biggest key first."""
+        parts = []
+        for key, count in self.counts.most_common():
+            part = f"{key} {count:,}"
+            if with_examples and self.examples.get(key):
+                part += f" (e.g. {', '.join(self.examples[key])})"
+            parts.append(part)
+        return ", ".join(parts)
+
+
+def progress[T](
+    iterable: Iterable[T],
+    desc: str,
+    total: int | None = None,
+    logger: logging.Logger | None = None,
+) -> Iterator[T]:
+    """Iterate with a tqdm bar on a TTY, and one summary line either way.
+
+    `disable=None` is tqdm's own "only draw on a TTY" mode, so a redirected
+    agent console gets the summary line and nothing else.
+    """
+    from tqdm import tqdm
+
+    log = logger or get_logger(__name__)
+    if total is None:
+        try:
+            total = len(iterable)  # type: ignore[arg-type]
+        except TypeError:
+            total = None
+
+    disable = {"auto": None, "on": False, "off": True}[_progress_mode]
+    count = 0
+    started = time.monotonic()
+    for item in tqdm(iterable, desc=desc, total=total, disable=disable):
+        count += 1
+        yield item
+    log.info("%s: %d items in %.1fs", desc, count, time.monotonic() - started)

--- a/src/utils/register_model.py
+++ b/src/utils/register_model.py
@@ -68,12 +68,11 @@ def register_model_to_clearml(
         "imgsz": imgsz,
         "task": task_yolo,
     }
-    logger.info("Config dict: %s", config_dict)
+    logger.debug("config dict: %s", config_dict)
     output_model.update_design(config_dict=config_dict)
     output_model.set_metadata("imgsz", str(imgsz), "int")
     output_model.set_metadata("task", task_yolo, "str")
     output_model.set_metadata("format", format_model, "str")
 
-    logger.info(
-        "Model registered with ClearML: %s | %s | %s", name_model, output_model.id, url_model
-    )
+    logger.info("registered %s with ClearML: %s", name_model, output_model.id)
+    logger.debug("model url: %s", url_model)

--- a/src/yolov8/callbacks.py
+++ b/src/yolov8/callbacks.py
@@ -72,32 +72,37 @@ def _log_plot(title, plot_path) -> None:
     """
     img = mpimg.imread(plot_path)
     fig = plt.figure()
-    ax = fig.add_axes(
-        [0, 0, 1, 1], frameon=False, aspect="auto", xticks=[], yticks=[]
-    )  # no ticks
-    ax.imshow(img)
+    try:
+        ax = fig.add_axes(
+            [0, 0, 1, 1], frameon=False, aspect="auto", xticks=[], yticks=[]
+        )  # no ticks
+        ax.imshow(img)
 
-    series = ""
-    if "confusion_matrix" in title:
-        series = title
-        title = "Confusion Matrix"
-    if "Mask" in title:
-        series = title
-        title = "Mask"
-    if "Box" in title:
-        series = title
-        title = "Box"
-    if "labels" in title:
-        series = title
-        title = "Labels"
+        series = ""
+        if "confusion_matrix" in title:
+            series = title
+            title = "Confusion Matrix"
+        if "Mask" in title:
+            series = title
+            title = "Mask"
+        if "Box" in title:
+            series = title
+            title = "Box"
+        if "labels" in title:
+            series = title
+            title = "Labels"
 
-    task: Task = Task.current_task()
-    task.get_logger().report_matplotlib_figure(
-        title=title,
-        series=series,
-        figure=fig,
-        report_interactive=False,
-    )
+        task: Task = Task.current_task()
+        task.get_logger().report_matplotlib_figure(
+            title=title,
+            series=series,
+            figure=fig,
+            report_interactive=False,
+        )
+    finally:
+        # pyplot keeps every figure alive until it is closed; this runs once per
+        # plot at the end of training.
+        plt.close(fig)
 
 
 def on_pretrain_routine_start(trainer: BaseTrainer):
@@ -360,7 +365,14 @@ def on_train_end(trainer: BaseTrainer):
             "format_model": "PyTorch",
             "data_yaml": data_yaml,
         }
-        logger.info("config_data: %s", config_data)
+        # data_yaml holds the full class list; keep it out of the INFO line.
+        logger.info(
+            "registering %s (%s, imgsz=%s) as best + last",
+            config_data["model_name"],
+            config_data["task_yolo"],
+            config_data["imgsz"],
+        )
+        logger.debug("config_data: %s", config_data)
 
         register_model_to_clearml(
             path_model=trainer.best,

--- a/src/yolov8/clearml_logger.py
+++ b/src/yolov8/clearml_logger.py
@@ -276,8 +276,40 @@ class YOLOClearMLLogger:
             )
             return True
         except Exception as e:
-            logger.warning("Failed to log scalar %s/%s: %s", title, series, e)
+            # DEBUG, not WARNING: this is called once per scalar, so a sick
+            # ClearML connection produced eleven warnings per epoch. The batch
+            # helpers below warn once for the whole group instead.
+            logger.debug("Failed to log scalar %s/%s: %s", title, series, e)
             return False
+
+    def _log_scalar_batch(
+        self,
+        title: str,
+        values: dict[str, float],
+        iteration: int,
+        what: str,
+    ) -> bool:
+        """Report a group of scalars and warn at most once for the group."""
+        task_logger = self._get_logger()
+        if task_logger is None:
+            return False
+
+        failed = [
+            name
+            for name, value in values.items()
+            if not self.log_scalar_grouped(title, name, value, iteration)
+        ]
+        if failed:
+            logger.warning(
+                "Failed to log %d/%d %s at iteration %s: %s",
+                len(failed),
+                len(values),
+                what,
+                iteration,
+                ", ".join(failed),
+            )
+            return False
+        return True
 
     def log_per_class_scatter(
         self,
@@ -359,16 +391,7 @@ class YOLOClearMLLogger:
             True if logged successfully, False otherwise.
 
         """
-        task_logger = self._get_logger()
-        if task_logger is None:
-            return False
-
-        success = True
-        for metric_name, value in speeds.items():
-            if not self.log_scalar_grouped(title, metric_name, value, iteration):
-                success = False
-
-        return success
+        return self._log_scalar_batch(title, speeds, iteration, "speed metrics")
 
     def log_learning_rates(
         self,
@@ -387,16 +410,7 @@ class YOLOClearMLLogger:
             True if logged successfully, False otherwise.
 
         """
-        task_logger = self._get_logger()
-        if task_logger is None:
-            return False
-
-        success = True
-        for group_name, lr_value in learning_rates.items():
-            if not self.log_scalar_grouped(title, group_name, lr_value, iteration):
-                success = False
-
-        return success
+        return self._log_scalar_batch(title, learning_rates, iteration, "learning rates")
 
     def log_loss_components(
         self,
@@ -415,13 +429,4 @@ class YOLOClearMLLogger:
             True if logged successfully, False otherwise.
 
         """
-        task_logger = self._get_logger()
-        if task_logger is None:
-            return False
-
-        success = True
-        for loss_name, value in losses.items():
-            if not self.log_scalar_grouped(title, loss_name, value, iteration):
-                success = False
-
-        return success
+        return self._log_scalar_batch(title, losses, iteration, "loss components")

--- a/src/yolov8/data.py
+++ b/src/yolov8/data.py
@@ -11,8 +11,6 @@ import shutil
 
 from typing import Any
 
-from rich import print
-
 from src.data.converter.coco2yolo import (
     Coco2Yolo,
     count_files_in_directory,
@@ -22,6 +20,10 @@ from src.data.downloader.method.cvat import CVATHTTPDownloaderV1, CVATHTTPDownlo
 from src.data.setup import setup_dataset
 from src.schema.coco import Coco as CocoSchema
 from src.utils.general import read_json
+from src.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class DataHandler:
@@ -127,10 +129,10 @@ class DataHandler:
         is_server1, _ = CVATHTTPDownloaderV1().get_about_server()
         is_server2, _ = CVATHTTPDownloaderV2().get_about_server()
         if is_server1:
-            print("[bold green]CVAT Server V1 detected[/bold green]")
+            logger.info("cvat: server V1 detected, %d train task(s)", len(task_id_train))
             cvat_http = CVATHTTPDownloaderV1()
         elif is_server2:
-            print("[bold green]CVAT Server V2 detected[/bold green]")
+            logger.info("cvat: server V2 detected, %d train task(s)", len(task_id_train))
             cvat_http = CVATHTTPDownloaderV2()
         else:
             raise ValueError("CVAT Server not found")
@@ -140,12 +142,16 @@ class DataHandler:
             task_ids=task_id_train,
             annotations_only=False,
         ):
-            print(f"\n📁 [cyan]Dataset[/cyan] {project_dir} 📁")
             ann_train_val = os.path.join(
                 project_dir, "annotations", "instances_default.json"
             )
             annotation_type = self._get_annotation_type(ann_train_val)
-            print(f"annotation_type: {annotation_type}, task_model: {self.task_model}")
+            logger.debug(
+                "%s: annotation_type=%s, task_model=%s",
+                project_dir,
+                annotation_type,
+                self.task_model,
+            )
             use_segments = (
                 "segmentation" in annotation_type and self.task_model != "detect"
             )
@@ -173,8 +179,13 @@ class DataHandler:
         else:
             self.dataset_test_dir = None
 
-        print(f"\n🧮 [yellow]TOTAL COUNT IMAGES[/yellow]: {total_count_files}")
-        print(f"label_names: {label_names}")
+        logger.info(
+            "cvat: %s images collected across %d task(s), %d classes",
+            f"{total_count_files:,}",
+            len(task_id_train) + len(task_id_test or []),
+            len(label_names),
+        )
+        logger.debug("label_names: %s", label_names)
         self._finalize_dataset(label_names)
 
     def _finalize_dataset(self, label_names: list[str]):
@@ -194,14 +205,14 @@ class DataHandler:
             valid_ratio=self.config["params"]["val_ratio"],
             test_ratio=self.config["params"].get("test_ratio"),
         )
+        counts = []
         for split in ["train", "valid", "test"]:
             dir_path = os.path.join(self.dataset_dir, split)
             img_count = count_files_in_directory(dir_path, extensions=image_extensions)
             lbl_count = count_files_in_directory(dir_path, extensions=["txt"])
-            print(
-                f"🧮 [{split.capitalize()}] TOTAL COUNT IMAGES: {img_count}"
-                f" | TOTAL COUNT LABELS: {lbl_count}"
-            )
+            if img_count or lbl_count:
+                counts.append(f"{split} {img_count:,} img / {lbl_count:,} lbl")
+        logger.info("dataset ready: %s", ", ".join(counts))
 
     def export(self) -> str:
         """Prepare and export the dataset for YOLOv8 training.
@@ -213,11 +224,11 @@ class DataHandler:
 
         """
         if self.source_type == "s3":
-            print("[yellow]S3 source not implemented yet.[/yellow]")
+            logger.warning("S3 source not implemented yet")
         elif self.source_type == "cvat":
             self._handle_cvat()
         elif self.source_type == "label_studio":
-            print("[yellow]Label Studio source not implemented yet.[/yellow]")
+            logger.warning("Label Studio source not implemented yet")
         else:
             raise ValueError(
                 "Cek config datanya pak. source must be s3, cvat or label_studio"
@@ -226,8 +237,6 @@ class DataHandler:
 
 
 if __name__ == "__main__":
-    from rich import print
-
     from schema.params import (  # noqa: F401
         args_augment,
         args_data,

--- a/src/yolov8/exporter.py
+++ b/src/yolov8/exporter.py
@@ -1,14 +1,19 @@
 import os
+import time
 
 from typing import Any, Literal
 
 import torch
 import yaml
 
-from clearml import OutputModel, Task
-from rich import print
 from ultralytics import YOLO
 from yaml.loader import SafeLoader
+
+from src.utils.logging import get_logger
+from src.utils.register_model import register_model_to_clearml
+
+
+logger = get_logger(__name__)
 
 
 # Constants for format-specific parameters
@@ -28,6 +33,22 @@ FORMAT_PARAMETERS = {
     ],
     "engine": None,  # None indicates that all parameters should be used
 }
+
+
+def _size_mb(path: str) -> float:
+    """Size of an exported artifact -- openvino produces a directory, not a file."""
+    if os.path.isfile(path):
+        return os.path.getsize(path) / 1024**2
+    if os.path.isdir(path):
+        return (
+            sum(
+                os.path.getsize(os.path.join(root, name))
+                for root, _, files in os.walk(path)
+                for name in files
+            )
+            / 1024**2
+        )
+    return 0.0
 
 
 def load_data_yaml(dataset_folder: str) -> dict:
@@ -55,9 +76,9 @@ def export_model_format(
     yolo: YOLO, format_model: str, imgsz: int, export_params: dict[str, Any]
 ) -> str:
     """Export model in the specified format with appropriate parameters."""
-    print(f"Exporting {format_model.upper()}...")
+    logger.debug("exporting %s (imgsz=%s)", format_model, imgsz)
     if format_model == "engine":
-        print("torch.cuda.is_available():", torch.cuda.is_available())
+        logger.debug("torch.cuda.is_available(): %s", torch.cuda.is_available())
         return yolo.export(
             format=format_model,
             imgsz=imgsz,
@@ -66,7 +87,7 @@ def export_model_format(
         )
 
     filtered_params = filter_export_parameters(format_model, export_params)
-    print(f"Using parameters for `{format_model.upper()}`: {filtered_params}")
+    logger.debug("parameters for %s: %s", format_model, filtered_params)
 
     if "fraction" in yolo.overrides:
         yolo.overrides.pop("fraction")
@@ -78,49 +99,6 @@ def export_model_format(
         format=format_model,
         imgsz=imgsz,
         **filtered_params,
-    )
-
-
-def register_model_with_clearml(
-    path_model: str,
-    format_model: str,
-    model_name: str,
-    data_yaml: dict,
-    task_yolo: str,
-    imgsz: int,
-) -> None:
-    """Register the exported model with ClearML."""
-    name_model = f"{format_model}-{model_name}"
-    target_filename = f"{name_model}.{format_model}"
-    task: Task = Task.current_task()
-    output_model = OutputModel(
-        task=task,
-        name=name_model,
-        comment=str(data_yaml["names"])
-        + "\n this CONVERTED BY USING BEST VERSION of this Experiment",
-        label_enumeration={lbl: idx for idx, lbl in enumerate(data_yaml["names"])},
-        tags=[task_yolo, task.id],
-    )
-
-    url_model = output_model.update_weights(
-        weights_filename=path_model,
-        target_filename=target_filename,
-        auto_delete_file=False,
-    )
-    output_model.wait_for_uploads()
-
-    config_dict = {
-        "net": model_name.replace(".pt", ""),
-        "imgsz": imgsz,
-        "task": task_yolo,
-    }
-    print(f"Config dict: {config_dict}")
-    output_model.update_design(config_dict=config_dict)
-    output_model.set_metadata("imgsz", imgsz, "int")
-    output_model.set_metadata("task", task_yolo, "str")
-
-    print(
-        f"Model registered with ClearML: {name_model} | {output_model.id} | {url_model}"
     )
 
 
@@ -152,18 +130,18 @@ def export_handler(
     Raises
     ------
     Exception
-        If an error occurs during model export, it is caught and printed, and the process
+        If an error occurs during model export, it is caught and logged, and the process
         continues for other formats.
 
     """
-    print("\n[Export Model]")
-
+    # No banner here: src/train.py already logs "[Exporting Model]".
     data_yaml = load_data_yaml(dataset_folder)
 
-    for format_model, is_use in args_export["format"].items():
-        if not is_use:
-            continue
+    requested = [fmt for fmt, is_use in args_export["format"].items() if is_use]
+    succeeded = 0
 
+    for format_model in requested:
+        started = time.monotonic()
         try:
             path_model = export_model_format(
                 yolo=yolo,
@@ -171,9 +149,13 @@ def export_handler(
                 imgsz=args_training["imgsz"],
                 export_params=args_export["params"],
             )
-            print(f"Exported to: {path_model}")
 
-            register_model_with_clearml(
+            # One implementation of registration, in src/utils/register_model.py.
+            # The copy that used to live here logged the same two lines with the
+            # same wording -- that is where the "duplicate" messages came from --
+            # and had already drifted: no `format` metadata, no lifecycle tags,
+            # and imgsz sent as an int to a field declared "int" as a string.
+            register_model_to_clearml(
                 path_model=path_model,
                 format_model=format_model,
                 model_name=args_task["model_name"],
@@ -181,10 +163,22 @@ def export_handler(
                 task_yolo=task_yolo,
                 imgsz=args_training["imgsz"],
             )
+            succeeded += 1
+            logger.info(
+                "export %s: ok in %.1fs -> %s (%.1f MB)",
+                format_model,
+                time.monotonic() - started,
+                os.path.basename(str(path_model).rstrip("/")),
+                _size_mb(str(path_model)),
+            )
 
         except Exception as e:
-            import traceback
-
-            traceback.print_exc()
-            print(f"Error exporting to {format_model}: {e}")
+            # TensorRT without a GPU is an absent capability, not a defect --
+            # warn rather than raising the alarm with a full traceback.
+            if format_model == "engine" and not torch.cuda.is_available():
+                logger.warning("export engine: skipped, no CUDA device available (%s)", e)
+            else:
+                logger.exception("export %s: failed", format_model)
             continue
+
+    logger.info("export: %d/%d formats ok", succeeded, len(requested))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+"""Shared fixtures.
+
+The one that matters is `capture_src_logs`. pytest's own `caplog` captures
+through a handler on the *root* logger, and `src/utils/logging.py` sets
+`propagate = False` on the `src` logger on purpose -- so `caplog.records` is
+always empty here and any "we emit N lines" assertion built on it passes
+vacuously. Capture on the `src` logger directly instead.
+"""
+
+import logging
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+
+import pytest
+
+from src.utils import logging as src_logging
+
+
+class _ListHandler(logging.Handler):
+    """Collects records instead of writing them anywhere."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _reset_logging_state() -> None:
+    root = logging.getLogger(src_logging.ROOT_LOGGER_NAME)
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    root.setLevel(logging.NOTSET)
+    root.propagate = True
+    src_logging._configured = False
+    src_logging._progress_mode = "auto"
+    src_logging._warned_values.clear()
+
+
+@pytest.fixture
+def reset_src_logging() -> Iterator[None]:
+    """Drop the logging module's global handler/`_configured` state.
+
+    Tests that flip `LOG_LEVEL` need the next `setup_logging()` to actually
+    reconfigure rather than short-circuit on a leftover handler.
+    """
+    _reset_logging_state()
+    yield
+    _reset_logging_state()
+
+
+@pytest.fixture
+def capture_src_logs() -> Iterator[Callable[..., object]]:
+    """Context manager yielding the records emitted under the `src` logger."""
+
+    @contextmanager
+    def _capture(
+        level: int = logging.INFO,
+        name: str = src_logging.ROOT_LOGGER_NAME,
+    ) -> Iterator[list[logging.LogRecord]]:
+        # Deliberately does not call setup_logging(): that would emit the
+        # first-configuration output (e.g. the unreadable-LOG_LEVEL warning)
+        # before the handler is attached, so tests would never see it.
+        logger = logging.getLogger(name)
+        handler = _ListHandler()
+        handler.setLevel(level)
+        previous_level = logger.level
+        logger.setLevel(level)
+        logger.addHandler(handler)
+        try:
+            yield handler.records
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(previous_level)
+
+    return _capture

--- a/tests/data/test_data_stage_smoke.py
+++ b/tests/data/test_data_stage_smoke.py
@@ -1,0 +1,241 @@
+"""Fast smoke + log-volume tests for the data preparation stage.
+
+The stage that produced the most console noise had no test at all: reaching it
+for real needs CVAT credentials and a few minutes. These build a miniature COCO
+tree in tmp_path instead and run the same code, in milliseconds. Not marked
+`slow` -- nothing here downloads or trains.
+
+The volume assertions are written as *scale invariance*, not as fixed line
+counts: what matters is that a dataset ten times the size does not produce ten
+times the log.
+"""
+
+import json
+import logging
+
+from pathlib import Path
+
+import pytest
+
+from src.data.converter.coco2yolo import Coco2Yolo
+from src.data.setup import setup_dataset, split_folder_yolo
+from src.schema.coco import Coco as CocoSchema
+
+
+CATEGORIES = [
+    {"id": 1, "name": "fruit", "supercategory": ""},
+    {"id": 2, "name": "stalk", "supercategory": ""},
+]
+
+
+def _annotation(
+    ann_id: int, image_id: int, category_id: int, area: float = 100.0
+) -> dict:
+    # Geometry has to differ per annotation: the converter drops duplicate boxes
+    # and duplicate segments, so identical shapes would collapse into one line.
+    x = float(ann_id % 5) * 10.0
+    return {
+        "id": ann_id,
+        "image_id": image_id,
+        "category_id": category_id,
+        "segmentation": [[x, 0.0, x + 10, 0.0, x + 10, 10.0, x, 10.0]],
+        "area": area,
+        "bbox": [x, 0.0, 10.0, 10.0],
+        "iscrowd": 0,
+        "attributes": {"maturity_truth": "ripe"},
+    }
+
+
+def _coco_dict(n_images: int, anns_per_image: int) -> dict:
+    images = [
+        {
+            "id": i,
+            "width": 64,
+            "height": 64,
+            "file_name": f"img_{i}.jpg",
+            "license": 0,
+            "flickr_url": None,
+            "coco_url": None,
+            "date_captured": 0,
+        }
+        for i in range(1, n_images + 1)
+    ]
+    annotations = []
+    ann_id = 1
+    for img in images:
+        for k in range(anns_per_image):
+            # Alternate the classes so the excluded one is always represented.
+            annotations.append(_annotation(ann_id, img["id"], 1 if k % 2 else 2))
+            ann_id += 1
+    return {
+        "licenses": [],
+        "info": {
+            "year": "2026",
+            "version": "1",
+            "description": "",
+            "contributor": "",
+            "url": "",
+            "date_created": "",
+        },
+        "categories": CATEGORIES,
+        "images": images,
+        "annotations": annotations,
+    }
+
+
+def _write_project(root: Path, n_images: int, anns_per_image: int) -> Path:
+    """Write a COCO project the way CVAT lays it out: images/ + annotations/."""
+    from PIL import Image
+
+    project = root / "project"
+    (project / "images").mkdir(parents=True)
+    (project / "annotations").mkdir(parents=True)
+
+    for i in range(1, n_images + 1):
+        Image.new("RGB", (64, 64)).save(project / "images" / f"img_{i}.jpg")
+
+    (project / "annotations" / "instances_default.json").write_text(
+        json.dumps(_coco_dict(n_images, anns_per_image))
+    )
+    return project
+
+
+# --------------------------------------------------------------------------
+# Behaviour
+# --------------------------------------------------------------------------
+
+
+def test_convert_produces_a_yolo_tree(tmp_path: Path) -> None:
+    project = _write_project(tmp_path, n_images=5, anns_per_image=4)
+    out_dir = tmp_path / "dataset-yolov8"
+
+    output, categories, count = Coco2Yolo(
+        src_dir=str(project), output_dir=str(out_dir)
+    ).convert(use_segments=True, exclude_class=["stalk"])
+
+    assert Path(output) == out_dir
+    assert categories == ["fruit", "stalk"]
+    assert count == 5
+
+    images = sorted((out_dir / "images").iterdir())
+    labels = sorted((out_dir / "labels").iterdir())
+    assert len(images) == 5
+    assert len(labels) == 5
+
+    # Two of the four annotations per image were `stalk`, and stalk is excluded.
+    first_label = labels[0].read_text().strip().splitlines()
+    assert len(first_label) == 2
+    assert {line.split()[0] for line in first_label} == {"0"}
+
+
+def test_excluded_class_is_reported_not_written() -> None:
+    coco = CocoSchema(**_coco_dict(n_images=5, anns_per_image=4))
+    _anns, report = coco.get_imageid_to_annotations(exclude_class=["stalk"])
+
+    assert report.total == 20
+    assert report.kept == 10
+    assert report.dropped == 10
+    assert report.dropped_class["stalk"] == 10
+
+
+def test_area_filter_is_reported() -> None:
+    payload = _coco_dict(n_images=2, anns_per_image=2)
+    payload["annotations"][0]["area"] = 1.0
+    coco = CocoSchema(**payload)
+
+    _anns, report = coco.get_imageid_to_annotations(area_segment_min=50.0)
+
+    assert report.dropped_area == 1
+    assert report.kept == 3
+
+
+def test_setup_dataset_splits_and_writes_yaml(tmp_path: Path) -> None:
+    project = _write_project(tmp_path, n_images=10, anns_per_image=2)
+    out_dir = tmp_path / "dataset-yolov8"
+    _output, categories, _count = Coco2Yolo(
+        src_dir=str(project), output_dir=str(out_dir)
+    ).convert(use_segments=False)
+
+    setup_dataset(
+        dataset_dir=str(out_dir),
+        label_names=categories,
+        train_ratio=0.8,
+        valid_ratio=0.2,
+    )
+
+    # 8 / 1, not 8 / 2: num_valid is int(10 * (1 - 0.8)) and 1 - 0.8 is
+    # 0.19999999999999996 in binary floating point, so the last pair is dropped.
+    # Asserted as-is rather than fixed -- changing it would move every existing
+    # experiment's split.
+    assert len(list((out_dir / "train" / "images").iterdir())) == 8
+    assert len(list((out_dir / "valid" / "images").iterdir())) == 1
+    yaml_text = (out_dir / "data.yaml").read_text()
+    assert "nc: 2" in yaml_text
+    assert "train: train/images" in yaml_text
+
+
+# --------------------------------------------------------------------------
+# Log volume -- constant in the size of the dataset
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("n_annotations", [100, 10_000])
+def test_coco_filtering_volume_is_constant(capture_src_logs, n_annotations: int) -> None:
+    coco = CocoSchema(**_coco_dict(n_images=n_annotations // 4, anns_per_image=4))
+
+    with capture_src_logs(logging.INFO) as records:
+        coco.get_imageid_to_annotations(exclude_class=["stalk"])
+
+    assert len(records) == 1
+
+
+@pytest.mark.parametrize("n_images", [10, 200])
+def test_convert_volume_is_constant(
+    capture_src_logs, tmp_path: Path, n_images: int
+) -> None:
+    project = _write_project(tmp_path, n_images=n_images, anns_per_image=2)
+
+    with capture_src_logs(logging.INFO) as records:
+        Coco2Yolo(src_dir=str(project), output_dir=str(tmp_path / "out")).convert(
+            use_segments=False, exclude_class=["stalk"]
+        )
+
+    # Budget for one CVAT task: annotation filtering, label conversion, and the
+    # file layout summary.
+    assert len(records) == 3, [r.getMessage() for r in records]
+
+
+@pytest.mark.parametrize("n_images", [10, 200])
+def test_split_volume_is_constant(
+    capture_src_logs, tmp_path: Path, n_images: int
+) -> None:
+    project = _write_project(tmp_path, n_images=n_images, anns_per_image=2)
+    out_dir = tmp_path / "out"
+    Coco2Yolo(src_dir=str(project), output_dir=str(out_dir)).convert(use_segments=False)
+
+    with capture_src_logs(logging.INFO) as records:
+        split_folder_yolo(source_dir=str(out_dir), train_ratio=0.8, valid_ratio=0.2)
+
+    # The progress summary and the split summary.
+    assert len(records) == 2, [r.getMessage() for r in records]
+
+
+# 10 images minimum: with 5, num_valid is int(5 * (1 - 0.8)) == 0 and
+# creating_yaml_file then rejects the empty valid split. Pre-existing floating
+# point behaviour, out of scope for a logging change.
+@pytest.mark.parametrize("n_images", [10, 200])
+def test_setup_dataset_volume_is_constant(
+    capture_src_logs, tmp_path: Path, n_images: int
+) -> None:
+    project = _write_project(tmp_path, n_images=n_images, anns_per_image=2)
+    out_dir = tmp_path / "out"
+    _output, categories, _count = Coco2Yolo(
+        src_dir=str(project), output_dir=str(out_dir)
+    ).convert(use_segments=False)
+
+    with capture_src_logs(logging.INFO) as records:
+        setup_dataset(dataset_dir=str(out_dir), label_names=categories)
+
+    # split progress, split summary, data.yaml -- the plan's budget of 3 for
+    # "Split + data.yaml".
+    assert len(records) == 3, [r.getMessage() for r in records]

--- a/tests/utils/test_console_params.py
+++ b/tests/utils/test_console_params.py
@@ -1,0 +1,28 @@
+"""Guards for the console-verbosity parameters.
+
+`config_clearml()` folds `args_logging` and `args_augment` into `args_train`,
+and `args_train` is splatted straight into `model_yolo.train(**args_train)`.
+Ultralytics validates the keys and raises on unknown ones -- putting `log_level`
+in either of those dicts breaks every training run with
+"SyntaxError: 'log_level' is not a valid YOLO argument".
+"""
+
+from src.params import args_augment, args_console, args_logging, args_train
+
+
+def test_console_params_are_not_ultralytics_arguments() -> None:
+    for name, other in (("args_train", args_train), ("args_logging", args_logging)):
+        overlap = set(args_console) & set(other)
+        assert not overlap, f"{overlap} would reach YOLO.train() through {name}"
+
+
+def test_console_params_stay_out_of_the_dicts_merged_into_train() -> None:
+    merged = {**args_logging, **args_augment}
+    assert "log_level" not in merged
+    assert "progress" not in merged
+
+
+def test_console_defaults_defer_to_the_environment() -> None:
+    # Empty means "no opinion" so $LOG_LEVEL still wins; see resolve_level().
+    assert args_console["log_level"] == ""
+    assert args_console["progress"] == "auto"

--- a/tests/utils/test_logging.py
+++ b/tests/utils/test_logging.py
@@ -1,0 +1,187 @@
+"""Tests for the logging infrastructure everything else in the pipeline builds on."""
+
+import logging
+
+import pytest
+
+from src.utils.logging import (
+    ROOT_LOGGER_NAME,
+    get_logger,
+    is_tty,
+    progress,
+    resolve_level,
+    set_log_level,
+    setup_logging,
+)
+
+
+# Module state (`_configured`, the handler) is global and leaks between tests.
+pytestmark = pytest.mark.usefixtures("reset_src_logging")
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("debug", logging.DEBUG),
+        ("DEBUG", logging.DEBUG),
+        ("Warning", logging.WARNING),
+        ("10", logging.DEBUG),
+        ("", logging.INFO),
+        ("   ", logging.INFO),
+        ("nonsense", logging.INFO),
+    ],
+)
+def test_resolve_level_from_env(
+    monkeypatch: pytest.MonkeyPatch, env_value: str, expected: int
+) -> None:
+    # pytest.ini's `env =` block is inert (pytest-env is not installed), so the
+    # env var has to be set here.
+    monkeypatch.setenv("LOG_LEVEL", env_value)
+    assert resolve_level() == expected
+
+
+def test_resolve_level_defaults_to_info_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    assert resolve_level() == logging.INFO
+
+
+def test_explicit_level_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "ERROR")
+    assert resolve_level("DEBUG") == logging.DEBUG
+
+
+def test_blank_explicit_falls_through_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "ERROR")
+    assert resolve_level("") == logging.ERROR
+
+
+def test_unreadable_level_warns_rather_than_failing_silently(
+    monkeypatch: pytest.MonkeyPatch, capture_src_logs
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "louder-please")
+    with capture_src_logs(logging.WARNING) as records:
+        level = resolve_level()
+
+    assert level == logging.INFO
+    assert len(records) == 1
+    assert "louder-please" in records[0].getMessage()
+
+
+def test_unreadable_level_warns_once_not_once_per_module(
+    monkeypatch: pytest.MonkeyPatch, capture_src_logs
+) -> None:
+    """get_logger() calls setup_logging(), and every module calls get_logger()."""
+    monkeypatch.setenv("LOG_LEVEL", "louder-please")
+    with capture_src_logs(logging.WARNING) as records:
+        for name in ("src.a", "src.b", "src.c", "src.d"):
+            get_logger(name)
+
+    assert len(records) == 1
+
+
+def test_setup_does_not_undo_a_later_set_log_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "ERROR")
+    set_log_level(logging.DEBUG)
+    # A module imported after the level was raised must not reset it from the env.
+    assert get_logger("src.late").isEnabledFor(logging.DEBUG)
+
+
+def test_setup_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    setup_logging()
+    setup_logging()
+    setup_logging()
+    assert len(logging.getLogger(ROOT_LOGGER_NAME).handlers) == 1
+
+
+def test_no_double_print_when_root_logger_is_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard: ClearML calls logging.basicConfig() on the root logger."""
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    logger = get_logger("src.demo")
+
+    root_records: list[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            root_records.append(record)
+
+    src_records: list[logging.LogRecord] = []
+
+    class _SrcCollector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            src_records.append(record)
+
+    root_handler = _Collector()
+    src_handler = _SrcCollector()
+    logging.getLogger().addHandler(root_handler)
+    logging.getLogger(ROOT_LOGGER_NAME).addHandler(src_handler)
+    try:
+        logger.info("only once")
+    finally:
+        logging.getLogger().removeHandler(root_handler)
+        logging.getLogger(ROOT_LOGGER_NAME).removeHandler(src_handler)
+
+    assert len(src_records) == 1
+    assert root_records == []
+
+
+def test_names_outside_src_tree_are_normalized(
+    monkeypatch: pytest.MonkeyPatch, capture_src_logs
+) -> None:
+    """`make run` runs src/train.py as a script, so its __name__ is __main__."""
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    logger = get_logger("__main__")
+
+    assert logger.name.startswith(f"{ROOT_LOGGER_NAME}.")
+    with capture_src_logs(logging.INFO) as records:
+        logger.info("reachable")
+    assert len(records) == 1
+
+
+def test_src_names_are_left_alone() -> None:
+    assert get_logger("src.data.setup").name == "src.data.setup"
+
+
+def test_set_log_level_reconfigures_after_setup(
+    monkeypatch: pytest.MonkeyPatch, capture_src_logs
+) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    logger = get_logger("src.demo")
+    assert not logger.isEnabledFor(logging.DEBUG)
+
+    set_log_level(logging.DEBUG)
+    assert logger.isEnabledFor(logging.DEBUG)
+
+    with capture_src_logs(logging.DEBUG) as records:
+        logger.debug("now visible")
+    assert len(records) == 1
+
+
+def test_debug_is_invisible_at_default_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    logger = get_logger("src.demo")
+
+    # Asserted on the logger rather than on captured records: capture_src_logs
+    # lowers the level to whatever it is asked to capture, which would mask this.
+    assert not logger.isEnabledFor(logging.DEBUG)
+    assert logger.isEnabledFor(logging.INFO)
+
+
+def test_is_tty_is_evaluated_lazily(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("sys.stdout", type("_NoTTY", (), {})())
+    assert is_tty() is False
+
+
+def test_progress_emits_exactly_one_summary_line(capture_src_logs) -> None:
+    with capture_src_logs(logging.INFO) as records:
+        consumed = list(progress(range(500), desc="units"))
+
+    assert len(consumed) == 500
+    assert len(records) == 1
+    assert "500 items" in records[0].getMessage()

--- a/tests/utils/test_no_print.py
+++ b/tests/utils/test_no_print.py
@@ -1,0 +1,88 @@
+"""Ban bare print() and `from rich import print` in pipeline code.
+
+ruff's T20 covers `print(...)` but is blind to the rich alias: `from rich import
+print` rebinds the name, so a call site looks identical to the linter and gets a
+pass. Four modules in this repository used to do exactly that. This walks the
+AST instead of trusting the name.
+"""
+
+import ast
+
+from pathlib import Path
+
+import pytest
+
+
+SRC = Path(__file__).resolve().parents[2] / "src"
+SOURCE_FILES = sorted(SRC.rglob("*.py"))
+
+
+def _is_main_guard(node: ast.stmt) -> bool:
+    """Whether `node` is `if __name__ == "__main__":`."""
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+        and any(
+            isinstance(c, ast.Constant) and c.value == "__main__"
+            for c in test.comparators
+        )
+    )
+
+
+def _prints_outside_main(tree: ast.Module) -> list[int]:
+    """Line numbers of print() calls not inside an `if __name__` block."""
+    exempt: set[int] = set()
+    for node in tree.body:
+        if _is_main_guard(node):
+            exempt.update(
+                child.lineno for child in ast.walk(node) if hasattr(child, "lineno")
+            )
+
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "print"
+        and node.lineno not in exempt
+    ]
+
+
+def _rich_print_imports(tree: ast.Module) -> list[int]:
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "rich"
+        and any(alias.name == "print" for alias in node.names)
+    ]
+
+
+def test_the_scan_actually_sees_files() -> None:
+    """A glob that silently matched nothing would make both tests below vacuous."""
+    assert len(SOURCE_FILES) > 10
+
+
+@pytest.mark.parametrize("path", SOURCE_FILES, ids=lambda p: str(p.name))
+def test_no_bare_print(path: Path) -> None:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders = _prints_outside_main(tree)
+    assert not offenders, (
+        f"{path.relative_to(SRC.parent)} calls print() at line(s)"
+        f" {offenders} -- use src.utils.logging.get_logger instead"
+    )
+
+
+@pytest.mark.parametrize("path", SOURCE_FILES, ids=lambda p: str(p.name))
+def test_no_rich_print_import(path: Path) -> None:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    offenders = _rich_print_imports(tree)
+    assert not offenders, (
+        f"{path.relative_to(SRC.parent)} imports rich.print at line(s) {offenders}"
+        " -- it shadows the builtin, so T20 cannot see the call sites,"
+        " and its markup prints literally through a plain handler"
+    )


### PR DESCRIPTION
## Kenapa

Run agent sungguhan (3 epoch, 4 task CVAT) menghasilkan **334 baris** output milik kita sendiri — **340 di antaranya `print()` telanjang** berbanding 30 pemanggilan `logger`. Stage prepare data memakai **nol** logger. `src/schema/coco.py` mencetak satu baris **per anotasi** di dalam loop atas seluruh anotasi; dengan `class_exclude` default yang dikirim repo, itu puluhan ribu baris. Level di-hardcode `INFO`, jadi dua `logger.debug` yang sudah tertulis di `train.py` tidak pernah bisa muncul.

## Aturan yang jadi inti perubahan

> Tidak boleh ada baris INFO yang keluar dari dalam loop atas item dataset.

Loop menghitung (`Tally`), pemanggil mencetak satu ringkasan. Volume log berhenti mengikuti ukuran dataset.

Diukur nyata pada 400 gambar / 2.400 anotasi:

```
INFO | src.schema.coco              | annotations: 2,400 total -> 1,200 kept, 1,200 dropped (class 1,200 [stalk 1,200])
INFO | src.data.converter.coco2yolo | coco -> yolo labels: 400 items in 0.0s
INFO | src.data.converter.coco2yolo | project: 400 images -> 400 copied, 0 without labels (labels on disk 400, match=True)
INFO | src.data.setup               | splitting files: 399 items in 0.0s
INFO | src.data.setup               | split: 400 pairs -> train 320 / valid 79
INFO | src.data.setup               | data.yaml: 2 classes, splits train/valid
```

Enam baris — sama persis dengan run 5 gambar. `LOG_LEVEL=debug` mengembalikan 1.208 baris.

## Isi

**Infrastruktur** (`src/utils/logging.py`) — satu handler di logger `src` dengan `propagate=False`, karena ClearML memanggil `basicConfig()` di root logger dan setiap baris kita akan tercetak dua kali. Nama logger di luar pohon `src.` dinormalisasi (`make run` menjalankan train.py sebagai skrip, `__name__`-nya `__main__`). Level dibaca langsung dari `os.environ`, bukan lewat `src/config.py` yang meledak saat import kalau ada field kosong.

**Kenop verbositas** — `args_console` (`0_Console` di UI) plus `$LOG_LEVEL`. Dict tersendiri, **bukan** `args_logging`: `config_clearml()` melebur `args_logging` ke `args_train` dan ultralytics menolak key asing (`'log_level' is not a valid YOLO argument`).

**Bug yang sekalian diperbaiki**

- Loop poll CVAT tidak punya backoff sama sekali → `time.sleep(2)`.
- Jalur timeout memakai `break` sehingga `file_name_zip` unbound — timeout muncul sebagai `UnboundLocalError`, bukan pesan timeout yang baru saja ditulis. Sekarang `raise`.
- URL dibuang dari log error CVAT, dan `CVAT_HOST` dari `config.py`: repo ini publik dan console task terbaca satu project.
- `setup_directory` membandingkan tersalin-vs-terlewat sebagai sanity check, relasi yang tidak bermakna. Sekarang: keduanya harus menjumlah jadi total gambar sumber.
- `register_model_with_clearml` dihapus — duplikat kata-per-kata dari `register_model_to_clearml`, **penyebab sebenarnya** pesan registrasi ganda, dan sudah menyimpang (tanpa metadata `format`, tanpa tag lifecycle, `imgsz` int ke field bertipe string).
- `_log_plot` tidak pernah menutup figure-nya.
- Peringatan per-scalar di `clearml_logger` berada di dalam loop → 11 peringatan per epoch saat ClearML bermasalah. Diagregasi per batch.
- Progress bar download dibuang: baris di atasnya sudah menarik seluruh body ke memori lewat `response.content`, jadi bar itu mengukur `memcpy`.

**Pagar pengaman** — ruff `T20` melarang `print()`. T20 buta terhadap `from rich import print` (4 modul memakainya), jadi `tests/utils/test_no_print.py` menyusuri AST. `tests/data/test_data_stage_smoke.py` menjalankan tiap stage di dua ukuran input dan mengasersi jumlah baris yang sama — invariansi skala, bukan angka ajaib — sekaligus menutup stage data yang selama ini tidak punya test sama sekali.

## Kenapa tag image naik ke 0.2.1

Image memanggang salinan `src/` yang membayangi checkout saat runtime. Dibuktikan di dalam container:

```
$ docker run -v <clone>:/clone -w /clone yolo-trainer:0.2.0 python src/_probe.py
resolved to: /workspace/src/utils/logging.py
has resolve_level: False
```

Agent yang memakai 0.2.0 akan mengimpor modul logging lama dan mati di `ImportError` sebelum menyentuh kode training. Tag lama tidak boleh ditimpa karena task lama menyimpan tag yang dipakainya saat dibuat.

## Verifikasi

- `145 passed` termasuk `-m slow`.
- ruff: **nol temuan baru** (79 vs 89 di baseline), nol pelanggaran T20 di `src/`.
- Satu kegagalan tersisa, `tests/data/converter/test_converter_coco2yolov.py`, sudah rusak sebelum perubahan ini (diverifikasi lewat `git stash`) — ia membongkar 2 nilai dari `convert()` yang mengembalikan 3. Begitu pula tiga modul yang gagal collect karena butuh `.env`.

## Sengaja tidak dikerjakan

`split_folder_yolo` menghitung `num_valid = int(total * (1 - 0.8))`, dan `1 - 0.8` adalah `0.19999999999999996`, jadi 10 gambar memberi 1 valid bukan 2. Test mengasersinya apa adanya dengan komentar: memperbaikinya menggeser split setiap eksperimen yang sudah ada. Tiga bug korektness metrik di `callbacks.py` juga dibiarkan — ketiganya mengubah angka di dashboard yang sudah jalan, dan kalau dibundel dengan pengurangan noise, reviewer tidak bisa tahu perubahan mana yang menggeser metrik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWcNQeoZdNv654tAmRQ7Lx