### PR TITLE
Sync uv.lock with the 0.2.1 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1809,7 +1809,7 @@ wheels = [
 
 [[package]]
 name = "template-yolov8"
-version = "0.2.0"
+version = "0.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "albumentations" },


### PR DESCRIPTION
`uv.lock` mencatat versi proyeknya sendiri, dan Dockerfile membangun dengan `uv sync --frozen`. Tertinggal di 0.2.0, build gagal sebelum memasang apa pun:

```
$ uv lock --check
error: The lockfile at `uv.lock` needs to be updated, but `--check` was provided.
```

Terlewat di #12. Satu baris, diverifikasi dengan `uv lock --check` sebelum dan sesudah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWcNQeoZdNv654tAmRQ7Lx