### PR TITLE
Make the train/valid/test split a partition, not three loose slices

### DIFF
--- a/docs/configurations/2_data.md
+++ b/docs/configurations/2_data.md
@@ -15,8 +15,8 @@ Everything about *which* images and *which* labels the run trains on lives in `a
 | `s3.s3_uri_dir_train` | `None` | — | **Not implemented.** Setting it only selects the S3 branch, which logs a warning and does nothing |
 | `s3.s3_uri_dir_test` | `None` | — | **Not implemented**, as above |
 | `params.train_ratio` | `0.8` | float | Fraction of the merged training images that go to `train/` |
-| `params.val_ratio` | `0.2` | float | Fraction that goes to `valid/` — **only read when `test_ratio` is truthy** |
-| `params.test_ratio` | `None` | float or `None` | Truthy = also carve a `test/` split out of the training images. The number itself is never used as a size |
+| `params.val_ratio` | `0.2` | float | Fraction that goes to `valid/`. **Only read when `test_ratio` is set** — without a test split, `valid/` takes everything that is not training, and a `val_ratio` that disagrees is warned about |
+| `params.test_ratio` | `None` | float or `None` | Fraction that goes to `test/`, or `None` for no test split. When set, the three ratios must sum to 1, and it is mutually exclusive with `task_ids_test` / `project_ids_test` |
 | `class_exclude` | `"stalk, foreign_object"` | comma-separated string or list | Class names whose annotations are dropped, and which reserve no class index |
 | `attributes_exclude` | `None` | `dict[str, str]` or `None` | Drop annotations whose CVAT attribute value matches. Only the **first** key of the dict is ever evaluated — see below |
 | `area_segment_min` | `0` | number | Drop annotations whose COCO `area` is strictly below this. `0` is a no-op |
@@ -132,14 +132,16 @@ The resolved source name is also used as a ClearML tag — `task.add_tags(handle
 
 ### What it does
 
-`split_folder_yolo()` (`src/data/setup.py:105`) collects every image that has a matching `.txt` label, shuffles with `random.seed(42)` (fixed, so the split is reproducible across runs on the same file set), and slices:
+`split_folder_yolo()` (`src/data/setup.py:120`) collects every image that has a matching `.txt` label, shuffles with `random.seed(42)` (fixed, so the split is reproducible across runs on the same file set), and partitions:
 
 ```python
 num_train = int(total_files * train_ratio)
 if test_ratio:
     num_valid = int(total_files * valid_ratio)
+    num_test  = total_files - num_train - num_valid   # remainder lands here
 else:
-    num_valid = int(total_files * (1 - train_ratio))
+    num_valid = total_files - num_train               # remainder lands here
+    num_test  = 0
 
 ls_train = ls_images_labels[:num_train]
 ls_valid = ls_images_labels[num_train : num_train + num_valid]
@@ -147,22 +149,27 @@ if test_ratio:
     ls_test  = ls_images_labels[num_train + num_valid :]
 ```
 
-### Three things about this that surprise people
+**The sizes are a partition: every pair lands in exactly one split, and the three counts sum to the input.** `tests/data/test_split_partition.py` asserts that at several sizes and ratios. This matters because the splits are built by *moving* files and the staging `images/` and `labels/` directories are `rmtree`d afterwards — anything that falls outside every slice is not left lying around, it is deleted.
 
-**1. `val_ratio` is ignored unless `test_ratio` is set.** With the defaults (`test_ratio = None`), the valid split is `int(n * (1 - train_ratio))` — `val_ratio` is not read at all. Setting `train_ratio=0.8, val_ratio=0.1` and leaving `test_ratio` empty still gives you a 20% valid split.
+### Two things about this that surprise people
 
-**2. The documented floating-point quirk: `int(n * (1 - 0.8))` drops a pair.** `1 - 0.8` is `0.19999999999999996` in IEEE 754, so:
+**1. `val_ratio` is ignored unless `test_ratio` is set.** With the defaults (`test_ratio = None`), `valid/` takes everything that is not training — `val_ratio` is not read as a size at all. Setting `train_ratio=0.8, val_ratio=0.1` and leaving `test_ratio` empty still gives you a 20% valid split, and now logs a `WARNING` saying so:
 
-| n | `int(n * 0.8)` | `int(n * (1 - 0.8))` | placed | dropped |
-|---|---|---|---|---|
-| 10 | 8 | 1 | 9 | 1 |
-| 20 | 16 | 3 | 19 | 1 |
-| 100 | 80 | 19 | 99 | 1 |
-| 1,000 | 800 | 199 | 999 | 1 |
+```
+WARNING | src.data.setup | valid_ratio=0.1 ignored: without a test split valid/ takes the remaining 0.20 of the pairs. Set test_ratio to size valid/ explicitly.
+```
 
-The tail pair is never moved into a split, and `split_folder_yolo` then `rmtree`s the staging `images/` and `labels/` directories — so it is discarded, not left lying around. One image out of a dataset is not worth worrying about; knowing *why* the counts do not add up is, because `test_a_training_project_excludes_its_own_test_task` asserts `(16, 3)` on 20 pairs and that looks like an error otherwise. Setting `test_ratio` takes the `int(n * val_ratio)` branch instead, which does not have the quirk.
+This is deliberate — "the rest goes to valid" is what a two-way split means — but it is worth knowing that the number you typed was not used.
 
-**3. `test_ratio`'s value is never used as a size — it is a switch.** The test split is whatever is *left over* after train and valid. So `train_ratio=0.8, val_ratio=0.2, test_ratio=0.1` on 1,000 images gives train 800, valid 200, test **0**, and `creating_yaml_file` then rejects the empty split. What you meant is `train_ratio=0.7, val_ratio=0.2, test_ratio=<anything truthy>` → 700 / 200 / 100. Note also that `test_ratio=0.0` is falsy and therefore means "no test split".
+**2. With `test_ratio` set, the three ratios must sum to 1.** `train_ratio=0.8, val_ratio=0.2, test_ratio=0.1` sums to 1.1 and is rejected before any file moves:
+
+```
+[Splitting] train_ratio=0.8, valid_ratio=0.2 and test_ratio=0.1 sum to 1.1, expected 1.0. Each ratio is the fraction of the dataset that goes to that split.
+```
+
+What you meant is `train_ratio=0.7, val_ratio=0.2, test_ratio=0.1` → 700 / 200 / 100. Note that `test_ratio=0.0` is falsy and therefore means "no test split", not "an empty test split".
+
+Both of these used to be silent. Until [#19](https://github.com/agfianf/template-yolov8-clearml/issues/19), `test_ratio` was a truthiness *switch* whose numeric value was never read — the test split was whatever was left over — so `0.8/0.1/0.9` and `0.8/0.1/0.1` produced an identical 80/10/10 split, and `0.8/0.2/0.1` produced an empty `test/` that was quietly dropped from `data.yaml`. The splits were also three independent `int()` slices rather than a partition, so `int(n * (1 - 0.8))` — `1 - 0.8` is `0.19999999999999996` in IEEE 754 — discarded the tail pair of every dataset whose size ended in a `0`.
 
 ### A ratio test split is not the same thing as `task_ids_test`
 
@@ -175,7 +182,13 @@ Two different mechanisms produce a `test/` directory, and they are not interchan
 | Removed from training? | Yes, by the slicing | Yes, by `resolve_task_scope` subtracting test from train |
 | Converted through the same class map? | Trivially | Yes — `_build_class_map(train_dirs + test_dirs)` sees both |
 
-**They collide.** `setup_dataset()` (`src/data/setup.py:201`) runs the ratio split first and then, if a dedicated test source exists, does `rmtree(f"{dataset_dir}/test")` and moves the dedicated set in. So configuring both means the ratio-derived test images are **deleted**, having already been withheld from training. Pick one.
+**They are mutually exclusive, and `setup_dataset()` refuses the combination** before the split runs:
+
+```
+[Splitting] test_ratio=0.1 and a dedicated test set (dataset-yolov8-test) are mutually exclusive -- configure one or the other. Carve the test split out of the training images with test_ratio, or point task_ids_test/project_ids_test at a test task and leave test_ratio empty.
+```
+
+The refusal is issue [#19](https://github.com/agfianf/template-yolov8-clearml/issues/19). Both mechanisms produce a `test/` directory in the same place, and the dedicated one used to win by `rmtree`ing it: the ratio held images back from training, the dedicated set then overwrote the directory holding them, and those images ended up in no split at all. With `0.8 / 0.1 / 0.1` that was 10% of every image downloaded from the training tasks, deleted with no warning — the only trace was that the `split:` and `dataset ready:` log lines reported different test counts. Neither answer could be picked automatically, because either one silently discards what the other configuration meant. Pick one yourself.
 
 Either way, once `data.yaml` has a `test:` entry, `src/train.py:317` sets `args_val["split"] = "test"` for the final validation pass, and every final report is titled `Test ...` instead of `Final ...`.
 
@@ -192,8 +205,10 @@ Either way, once `data.yaml` has a `test:` entry, `src/train.py:317` sets `args_
 | Mistake | Symptom |
 |---|---|
 | `train_ratio` so high the valid split rounds to 0 | `[Creating YAML] valid folder is not valid. images=0 labels=0 ...`, preceded by an ERROR line naming the counts and a few filenames |
-| `test_ratio` set to a number that leaves no remainder | Same failure for `test` — except `test` is allowed to be invalid, in which case it is quietly omitted from `data.yaml` and the run trains on without a test split |
-| Ratios that sum to more than 1 with `test_ratio` set | `ls_test` is an empty slice; no error until the yaml check |
+| Ratios that do not sum to 1 with `test_ratio` set | `[Splitting] ... sum to 1.1, expected 1.0`, raised before any file is moved |
+| `test_ratio` so small it rounds to 0 pairs | `[Splitting] test_ratio=... leaves no images for test/`, naming how many of the pairs `train_ratio` and `valid_ratio` already claim |
+| `test_ratio` **and** `task_ids_test` both set | `[Splitting] ... are mutually exclusive`, raised before the split runs |
+| A dedicated test task whose images are not annotated yet | `WARNING ... split "test" invalid (images=0 labels=0): omitted from data.yaml, the run will not evaluate on a test set`. Not fatal — training proceeds and the final `val()` falls back to the valid split |
 | No image/label pairs at all | `[Splitting] Error. No images found in the source directory!` |
 
 ---
@@ -571,9 +586,9 @@ Most common wins, so `speed_limit` is the displayed name. Fix it in CVAT anyway 
 ## Common mistakes
 
 1. **Leaving a test task in `task_ids_train` as well.** Harmless — the resolver subtracts it and says so — but if you see `0 excluded` where you expected 1, the id you typed is not the one in the project.
-2. **Expecting `val_ratio` to be honoured without `test_ratio`.** It is not read at all in that branch. The valid split is `1 - train_ratio`.
-3. **Treating `test_ratio` as a size.** It is a switch; the test split is the leftover. `0.8 / 0.2 / 0.1` produces an empty test split and a failed yaml check.
-4. **Configuring `test_ratio` *and* `task_ids_test`.** The ratio-derived `test/` is deleted and replaced. You lose those images from every split.
+2. **Expecting `val_ratio` to be honoured without `test_ratio`.** It is not read as a size in that branch — the valid split is everything that is not training, `1 - train_ratio`. A `val_ratio` that disagrees is warned about, not applied.
+3. **Ratios that do not sum to 1 with `test_ratio` set.** `0.8 / 0.2 / 0.1` sums to 1.1 and is rejected. Each ratio is that split's share of the dataset; write `0.7 / 0.2 / 0.1`.
+4. **Configuring `test_ratio` *and* `task_ids_test`.** Refused — they are two ways of producing the same `test/` directory. Pick one.
 5. **Spelling `class_exclude` with different case from CVAT.** The class map drops the name case-insensitively but the annotation filter matches case-sensitively, so the run dies with `UnknownClassError` naming a class you *did* exclude.
 6. **Putting two keys in `attributes_exclude`.** Only the first is evaluated, silently. And an annotation that does not carry the attribute crashes the run with `AttributeError`.
 7. **Reading `area_segment_min` as a fraction.** It is square pixels at source resolution.

--- a/src/data/setup.py
+++ b/src/data/setup.py
@@ -1,3 +1,4 @@
+import math
 import os
 import random
 import shutil
@@ -12,6 +13,10 @@ logger = get_logger(__name__)
 # How many filenames to show when a split fails its checks. Enough to recognise
 # the problem, not the whole listing -- these directories hold thousands.
 MAX_EXAMPLE_FILES = 5
+
+# Ratios are typed by hand into the ClearML UI, so they are compared with a
+# tolerance rather than for equality -- 0.7 + 0.2 + 0.1 is 0.9999999999999999.
+RATIO_TOLERANCE = 1e-6
 
 
 def _sample(dir_path: str) -> str:
@@ -65,6 +70,16 @@ def creating_yaml_file(source_dir, labels: list = None):
         if dir == "test":
             if is_passed:
                 use_test = True
+            else:
+                # Not fatal -- a test task whose images are not annotated yet
+                # should not stop training. But it is omitted from data.yaml and
+                # the final val() falls back to the valid split, so say so.
+                logger.warning(
+                    'split "test" invalid (images=%d labels=%d): omitted from'
+                    " data.yaml, the run will not evaluate on a test set",
+                    count_img,
+                    count_labels,
+                )
         elif not is_passed:
             # Counts and a handful of names. The previous version interpolated
             # two full os.listdir() results into one f-string.
@@ -103,11 +118,19 @@ def creating_yaml_file(source_dir, labels: list = None):
 
 
 def split_folder_yolo(source_dir, train_ratio=0.8, valid_ratio=0.2, test_ratio=None):
-    """Split folder yolo into train, valid, test (optional)
+    """Split a yolo folder into train, valid and an optional test split.
+
     source_dir: Directory path where the images and labels are located.
-    train_ratio: Ratio of the dataset to be used for training (default: 0.7).
-    valid_ratio: Ratio of the dataset to be used for validation (default: 0.15).
-    test_ratio: Ratio of the dataset to be used for testing (default: 0.15).
+    train_ratio: Fraction of the pairs that goes to `train/`.
+    valid_ratio: Fraction that goes to `valid/`. Only read when `test_ratio` is
+                 set; without a test split, `valid/` takes everything that is
+                 not training, and a `valid_ratio` that disagrees is warned about.
+    test_ratio: Fraction that goes to `test/`, or None for no test split. When
+                set, the three ratios must sum to 1.
+
+    The splits are a partition: every pair lands in exactly one of them. The
+    remainder left by integer truncation is assigned rather than discarded --
+    to `test/` when there is one, to `valid/` otherwise.
     """
     # Create train, valid, and test directories
     src_dir_images = os.path.join(source_dir, "images")
@@ -115,6 +138,17 @@ def split_folder_yolo(source_dir, train_ratio=0.8, valid_ratio=0.2, test_ratio=N
 
     if not os.path.exists(src_dir_images) and not os.path.exists(src_dir_labels):
         raise Exception("[Splitting] source_dir: images and labels directory not found")
+
+    # Checked before anything is moved: a wrong ratio should fail on the config,
+    # not halfway through a directory tree.
+    if test_ratio:
+        total_ratio = train_ratio + valid_ratio + test_ratio
+        if not math.isclose(total_ratio, 1.0, abs_tol=RATIO_TOLERANCE):
+            raise Exception(
+                f"[Splitting] train_ratio={train_ratio}, valid_ratio={valid_ratio}"
+                f" and test_ratio={test_ratio} sum to {total_ratio:g}, expected 1.0."
+                " Each ratio is the fraction of the dataset that goes to that split."
+            )
 
     dst_train_dir = os.path.join(source_dir, "train")
     dst_valid_dir = os.path.join(source_dir, "valid")
@@ -150,13 +184,34 @@ def split_folder_yolo(source_dir, train_ratio=0.8, valid_ratio=0.2, test_ratio=N
     random.seed(42)  # Ensure reproducibility across runs
     random.shuffle(ls_images_labels)
 
-    # Calculate the number of images for each set
+    # Calculate the number of images for each set. Sizes are a partition of
+    # `total_files`, so the truncation remainder is assigned to the last split
+    # instead of falling outside every slice and being deleted with the staging
+    # directories below.
     total_files = len(ls_images_labels)
     num_train = int(total_files * train_ratio)
     if test_ratio:
         num_valid = int(total_files * valid_ratio)
+        num_test = total_files - num_train - num_valid
+        if num_test <= 0:
+            raise Exception(
+                f"[Splitting] test_ratio={test_ratio} leaves no images for test/:"
+                f" train_ratio={train_ratio} and valid_ratio={valid_ratio} already"
+                f" claim {num_train + num_valid} of {total_files} pairs"
+            )
     else:
-        num_valid = int(total_files * (1 - train_ratio))
+        # No test split: valid/ takes everything that is not training, which is
+        # what the caller gets whatever `valid_ratio` says.
+        num_valid = total_files - num_train
+        num_test = 0
+        if not math.isclose(valid_ratio, 1 - train_ratio, abs_tol=RATIO_TOLERANCE):
+            logger.warning(
+                "valid_ratio=%s ignored: without a test split valid/ takes the"
+                " remaining %.2f of the pairs. Set test_ratio to size valid/"
+                " explicitly.",
+                valid_ratio,
+                1 - train_ratio,
+            )
 
     ls_train = ls_images_labels[:num_train]
     ls_valid = ls_images_labels[num_train : num_train + num_valid]
@@ -206,6 +261,19 @@ def setup_dataset(
     test_ratio=None,
     dataset_test=None,
 ):
+    # Both would produce a `test/`, and the dedicated one wins by overwriting the
+    # directory -- so the images `test_ratio` withheld from training would end up
+    # in no split at all. Refused rather than resolved: either answer silently
+    # discards what the other configuration meant.
+    if test_ratio and dataset_test:
+        raise Exception(
+            f"[Splitting] test_ratio={test_ratio} and a dedicated test set"
+            f" ({dataset_test}) are mutually exclusive -- configure one or the"
+            " other. Carve the test split out of the training images with"
+            " test_ratio, or point task_ids_test/project_ids_test at a test task"
+            " and leave test_ratio empty."
+        )
+
     creating_classes_txt(dataset_dir, label_names)
 
     split_folder_yolo(

--- a/src/params.py
+++ b/src/params.py
@@ -148,6 +148,12 @@ args_data = {
         "project_id_test": None,
     },
     "s3": {"s3_uri_dir_train": None, "s3_uri_dir_test": None},
+    # How the training pool is split. The three are a partition: every downloaded
+    # pair lands in exactly one split. `test_ratio` is the other way to get a
+    # `test/` directory, so it is mutually exclusive with `task_ids_test` /
+    # `project_ids_test` above and refused if both are set. Leave it None and the
+    # ratios are a two-way split: `valid_ratio` is then ignored, because valid/
+    # takes everything training does not. Set it and all three must sum to 1.
     "params": {
         "train_ratio": 0.8,
         "val_ratio": 0.2,

--- a/tests/data/test_data_handler_class_order.py
+++ b/tests/data/test_data_handler_class_order.py
@@ -228,11 +228,10 @@ def test_a_training_project_excludes_its_own_test_task() -> None:
     n_valid = len(list((dataset_dir / "valid" / "images").iterdir()))
     n_test = len(list((dataset_dir / "test" / "images").iterdir()))
 
-    # Two training tasks = 20 pairs, which `split_folder_yolo` turns into 16 + 3
-    # (the documented int(20 * (1 - 0.8)) rounding). Had TEST been trained on as
-    # well it would be 30 pairs -> 24 + 5, so these numbers *are* the assertion
-    # that the test task was excluded.
-    assert (n_train, n_valid) == (16, 3)
+    # Two training tasks = 20 pairs, which `split_folder_yolo` turns into 16 + 4.
+    # Had TEST been trained on as well it would be 30 pairs -> 24 + 6, so these
+    # numbers *are* the assertion that the test task was excluded.
+    assert (n_train, n_valid) == (16, 4)
     assert n_test == 10
 
 

--- a/tests/data/test_data_stage_smoke.py
+++ b/tests/data/test_data_stage_smoke.py
@@ -163,12 +163,13 @@ def test_setup_dataset_splits_and_writes_yaml(tmp_path: Path) -> None:
         valid_ratio=0.2,
     )
 
-    # 8 / 1, not 8 / 2: num_valid is int(10 * (1 - 0.8)) and 1 - 0.8 is
-    # 0.19999999999999996 in binary floating point, so the last pair is dropped.
-    # Asserted as-is rather than fixed -- changing it would move every existing
-    # experiment's split.
+    # 8 / 2, and 8 + 2 == 10: the splits partition the input. This used to be
+    # 8 / 1, because num_valid was int(10 * (1 - 0.8)) and 1 - 0.8 is
+    # 0.19999999999999996 in binary floating point, so the last pair fell outside
+    # every slice and was deleted with the staging directories. See
+    # tests/data/test_split_partition.py.
     assert len(list((out_dir / "train" / "images").iterdir())) == 8
-    assert len(list((out_dir / "valid" / "images").iterdir())) == 1
+    assert len(list((out_dir / "valid" / "images").iterdir())) == 2
     yaml_text = (out_dir / "data.yaml").read_text()
     assert "nc: 2" in yaml_text
     assert "train: train/images" in yaml_text

--- a/tests/data/test_split_partition.py
+++ b/tests/data/test_split_partition.py
@@ -1,0 +1,228 @@
+"""The train/valid/test split is a partition -- no pair is silently discarded.
+
+Every test here is a regression for issue #19. Before it, `split_folder_yolo`
+built three independent `int()` slices, so pairs could fall outside all of them
+and be deleted with the staging directories, and `test_ratio` was a truthiness
+switch whose numeric value was never read as a size. The worst case combined a
+`test_ratio` with a dedicated CVAT test set: the ratio withheld images from
+training and the dedicated set then overwrote the directory holding them.
+
+Pairs are written directly rather than converted from COCO -- these assert
+arithmetic on file counts, and a real annotation tree would only slow that down.
+"""
+
+import logging
+
+from pathlib import Path
+
+import pytest
+
+from src.data.setup import setup_dataset, split_folder_yolo
+
+
+def _make_pairs(root: Path, n: int, prefix: str) -> None:
+    """Write `n` image/label pairs under `root/images` and `root/labels`."""
+    (root / "images").mkdir(parents=True, exist_ok=True)
+    (root / "labels").mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        (root / "images" / f"{prefix}_{i:04d}.jpg").write_text("x")
+        (root / "labels" / f"{prefix}_{i:04d}.txt").write_text("0 0.5 0.5 0.2 0.2\n")
+
+
+def _counts(dataset_dir: Path) -> dict[str, int]:
+    out = {}
+    for split in ("train", "valid", "test"):
+        images = dataset_dir / split / "images"
+        out[split] = len(list(images.iterdir())) if images.is_dir() else 0
+    return out
+
+
+# --------------------------------------------------------------------------
+# Nothing is lost
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("n", "ratios"),
+    [
+        # 1 - 0.8 is 0.19999999999999996, so the old int(n * (1 - train_ratio))
+        # dropped the last pair of every dataset whose size ended in 0.
+        (100, (0.8, 0.2, None)),
+        (10, (0.8, 0.2, None)),
+        (100, (0.7, 0.2, 0.1)),
+        (13, (0.7, 0.2, 0.1)),
+        (7, (0.6, 0.2, 0.2)),
+    ],
+)
+def test_split_is_a_partition(tmp_path: Path, n: int, ratios: tuple) -> None:
+    dataset_dir = tmp_path / "dataset-yolov8"
+    _make_pairs(dataset_dir, n, "pool")
+    train_ratio, valid_ratio, test_ratio = ratios
+
+    split_folder_yolo(
+        source_dir=str(dataset_dir),
+        train_ratio=train_ratio,
+        valid_ratio=valid_ratio,
+        test_ratio=test_ratio,
+    )
+
+    counts = _counts(dataset_dir)
+    assert sum(counts.values()) == n, counts
+    # Labels travel with their image, so the label tree partitions identically.
+    for split, count in counts.items():
+        labels = dataset_dir / split / "labels"
+        assert (len(list(labels.iterdir())) if labels.is_dir() else 0) == count
+
+
+def test_remainder_goes_to_test_when_there_is_one(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset-yolov8"
+    _make_pairs(dataset_dir, 100, "pool")
+
+    split_folder_yolo(
+        source_dir=str(dataset_dir),
+        train_ratio=0.7,
+        valid_ratio=0.2,
+        test_ratio=0.1,
+    )
+
+    assert _counts(dataset_dir) == {"train": 70, "valid": 20, "test": 10}
+
+
+def test_remainder_goes_to_valid_without_a_test_split(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset-yolov8"
+    _make_pairs(dataset_dir, 100, "pool")
+
+    split_folder_yolo(source_dir=str(dataset_dir), train_ratio=0.8, valid_ratio=0.2)
+
+    assert _counts(dataset_dir) == {"train": 80, "valid": 20, "test": 0}
+
+
+# --------------------------------------------------------------------------
+# test_ratio is a size, not a switch
+# --------------------------------------------------------------------------
+
+
+def test_test_ratio_sizes_the_test_split(tmp_path: Path) -> None:
+    """0.6/0.2/0.2 and 0.6/0.2/0.1 used to produce the same 60/20/20 split."""
+    for test_ratio, expected in ((0.2, 20), (0.3, 30)):
+        dataset_dir = tmp_path / f"dataset-{test_ratio}"
+        _make_pairs(dataset_dir, 100, "pool")
+        split_folder_yolo(
+            source_dir=str(dataset_dir),
+            train_ratio=0.6,
+            valid_ratio=1.0 - 0.6 - test_ratio,
+            test_ratio=test_ratio,
+        )
+        assert _counts(dataset_dir)["test"] == expected
+
+
+@pytest.mark.parametrize("ratios", [(0.8, 0.2, 0.1), (0.8, 0.1, 0.9), (0.5, 0.2, 0.1)])
+def test_ratios_that_do_not_sum_to_one_are_rejected(
+    tmp_path: Path, ratios: tuple
+) -> None:
+    """(0.8, 0.2, 0.1) used to yield an empty test/ that was silently dropped."""
+    dataset_dir = tmp_path / "dataset-yolov8"
+    _make_pairs(dataset_dir, 100, "pool")
+    train_ratio, valid_ratio, test_ratio = ratios
+
+    with pytest.raises(Exception, match="expected 1.0"):
+        split_folder_yolo(
+            source_dir=str(dataset_dir),
+            train_ratio=train_ratio,
+            valid_ratio=valid_ratio,
+            test_ratio=test_ratio,
+        )
+
+    # Refused before anything moved: the staging tree is still intact.
+    assert len(list((dataset_dir / "images").iterdir())) == 100
+
+
+def test_valid_ratio_ignored_without_test_ratio_is_warned_about(
+    tmp_path: Path, caplog
+) -> None:
+    dataset_dir = tmp_path / "dataset-yolov8"
+    _make_pairs(dataset_dir, 100, "pool")
+
+    with caplog.at_level(logging.WARNING, logger="src.data.setup"):
+        split_folder_yolo(source_dir=str(dataset_dir), train_ratio=0.6, valid_ratio=0.1)
+
+    assert _counts(dataset_dir) == {"train": 60, "valid": 40, "test": 0}
+    assert any("valid_ratio=0.1 ignored" in r.getMessage() for r in caplog.records)
+
+
+def test_matching_valid_ratio_is_not_warned_about(tmp_path: Path, caplog) -> None:
+    dataset_dir = tmp_path / "dataset-yolov8"
+    _make_pairs(dataset_dir, 100, "pool")
+
+    with caplog.at_level(logging.WARNING, logger="src.data.setup"):
+        split_folder_yolo(source_dir=str(dataset_dir), train_ratio=0.8, valid_ratio=0.2)
+
+    assert not caplog.records
+
+
+# --------------------------------------------------------------------------
+# test_ratio vs a dedicated CVAT test set -- issue #19 proper
+# --------------------------------------------------------------------------
+
+
+def test_test_ratio_with_a_dedicated_test_set_is_refused(tmp_path: Path) -> None:
+    """The combination that used to delete `1 - train - valid` of the pool."""
+    dataset_dir = tmp_path / "dataset-yolov8"
+    dataset_test = tmp_path / "dataset-yolov8-test"
+    _make_pairs(dataset_dir, 100, "pool")
+    _make_pairs(dataset_test, 20, "cvattest")
+
+    with pytest.raises(Exception, match="mutually exclusive"):
+        setup_dataset(
+            dataset_dir=str(dataset_dir),
+            label_names=["fruit", "stalk"],
+            train_ratio=0.8,
+            valid_ratio=0.1,
+            test_ratio=0.1,
+            dataset_test=str(dataset_test),
+        )
+
+    # Refused before the split ran, so no pair has been moved or deleted yet.
+    assert len(list((dataset_dir / "images").iterdir())) == 100
+    assert len(list((dataset_test / "images").iterdir())) == 20
+
+
+def test_dedicated_test_set_alone_loses_nothing(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset-yolov8"
+    dataset_test = tmp_path / "dataset-yolov8-test"
+    _make_pairs(dataset_dir, 100, "pool")
+    _make_pairs(dataset_test, 20, "cvattest")
+
+    setup_dataset(
+        dataset_dir=str(dataset_dir),
+        label_names=["fruit", "stalk"],
+        train_ratio=0.8,
+        valid_ratio=0.2,
+        dataset_test=str(dataset_test),
+    )
+
+    assert _counts(dataset_dir) == {"train": 80, "valid": 20, "test": 20}
+    assert "test: test/images" in (dataset_dir / "data.yaml").read_text()
+
+
+def test_empty_dedicated_test_set_warns_instead_of_raising(
+    tmp_path: Path, caplog
+) -> None:
+    """A test task with no annotations yet should not stop a training run."""
+    dataset_dir = tmp_path / "dataset-yolov8"
+    dataset_test = tmp_path / "dataset-yolov8-test"
+    _make_pairs(dataset_dir, 100, "pool")
+    _make_pairs(dataset_test, 0, "cvattest")
+
+    with caplog.at_level(logging.WARNING, logger="src.data.setup"):
+        setup_dataset(
+            dataset_dir=str(dataset_dir),
+            label_names=["fruit", "stalk"],
+            train_ratio=0.8,
+            valid_ratio=0.2,
+            dataset_test=str(dataset_test),
+        )
+
+    assert _counts(dataset_dir) == {"train": 80, "valid": 20, "test": 0}
+    assert any('split "test" invalid' in r.getMessage() for r in caplog.records)
+    assert "test: test/images" not in (dataset_dir / "data.yaml").read_text()


### PR DESCRIPTION
Fixes #19.

## The root cause

`split_folder_yolo()` built each split from an independent `int()` slice, so nothing guaranteed the three covered the input. Pairs that fell outside every slice were not left lying around — the function `rmtree`s the staging `images/` and `labels/` directories afterwards, so they were deleted.

Three symptoms grew out of that one design, and every one of them was silent:

| | Before | After |
|---|---|---|
| `0.8 / 0.1 / 0.1` + `task_ids_test` on 100 + 20 pairs | train 80 / valid 10 / test 20 — **10 pairs deleted** | refused before anything moves |
| `0.8 / 0.1 / None` + `task_ids_test` on 100 + 20 | 80 / 19 / 20 — 1 pair lost to `1 - 0.8 == 0.19999999999999996` | 80 / 20 / 20, nothing lost |
| `0.8 / 0.2 / 0.1`, no dedicated test | empty `test/`, dropped from `data.yaml`, final `val()` silently falls back to the valid split | `[Splitting] ... sum to 1.1, expected 1.0` |
| `0.8 / 0.1 / 0.9`, no dedicated test | identical 80/10/10 — the value was never read as a size | same error, naming the sum |
| `0.6 / 0.1 / None` | 60 / 40, `val_ratio` discarded in silence | 60 / 40 plus a `WARNING` that says so |

The first row is the one that costs annotation work. Both mechanisms produce `<dataset_dir>/test`; the ratio held images back from training, and `setup_dataset()` then `rmtree`d the directory holding them to move the dedicated set in. With `0.8 / 0.1 / 0.1` that is 10% of every image downloaded from the training tasks, ending up in no split at all. The only trace was that the `split:` and `dataset ready:` log lines disagreed on the test count.

## What changed

**Sizes are a partition.** The truncation remainder is assigned rather than discarded — to `test/` when there is one, to `valid/` otherwise. Every pair lands in exactly one split, asserted at several sizes and ratios.

**`test_ratio` is a size.** With it set, the three ratios must sum to 1, checked before any file moves.

**`test_ratio` and a dedicated test set are refused together.** Neither answer to that collision could be picked automatically: ignoring the ratio silently changes what an existing config means, and honouring it silently ignores the test tasks. The error names both and says to pick one.

**An empty `test/` is treated by where it came from.** From ratios it raises, since it can only be a config error. From a dedicated test task it warns and the run proceeds — a test task whose images are not annotated yet should not stop training — but it now says out loud that `data.yaml` will have no test split and the final `val()` will fall back to `valid`.

**`val_ratio` keeps its "the rest goes to valid" meaning** without `test_ratio`, because that is what a two-way split means. A `val_ratio` that disagrees is now warned about instead of discarded in silence.

## Behaviour changes to be aware of

- **Existing tasks that set both `test_ratio` and `task_ids_test` will now fail at the data stage** instead of running with 10% of the data missing. That is the point, but it means a queued task with both set stops rather than starts.
- **Splits move for any config that set `test_ratio`,** and by one pair for configs whose dataset size made `int(n * (1 - train_ratio))` truncate. Past runs are not reproducible at fixed ratios. Two existing assertions encoded that leak — `(8, 1)` on 10 pairs and `(16, 3)` on 20 — and are updated to `(8, 2)` and `(16, 4)`.
- `params.py` defaults (`0.8 / 0.2 / None` with `task_ids_test: [730]`) are unaffected: no collision, no warning, and the split changes only by the one pair the rounding used to drop.

## Testing

- New `tests/data/test_split_partition.py`, 16 cases: partition invariance at five size/ratio combinations, remainder placement, `test_ratio` as a size, ratio-sum rejection, the `val_ratio` warning and its absence when the ratios agree, the collision refusal, and the empty-dedicated-test warning.
- All six cases from the issue's reproduction re-run against the fix. `LOST=0` everywhere it is not refused.
- Full suite: 337 passed. Excluded are the four modules that already fail at `main` — `tests/data/test_integration.py`, `tests/data/downloader/test_method_cvat_{http,sdk}.py` (stale imports, fail at collection) and `tests/data/converter/test_converter_coco2yolov.py` (wants a real CVAT download directory).
- `docs/configurations/2_data.md` rewritten where it documented the old behaviour, and `src/params.py` carries a comment on the mutual exclusion at the point where someone would set it.