### PR TITLE
Make attributes_exclude apply every rule, and survive a missing attribute

### DIFF
--- a/docs/configurations/2_data.md
+++ b/docs/configurations/2_data.md
@@ -18,7 +18,7 @@ Everything about *which* images and *which* labels the run trains on lives in `a
 | `params.val_ratio` | `0.2` | float | Fraction that goes to `valid/`. **Only read when `test_ratio` is set** — without a test split, `valid/` takes everything that is not training, and a `val_ratio` that disagrees is warned about |
 | `params.test_ratio` | `None` | float or `None` | Fraction that goes to `test/`, or `None` for no test split. When set, the three ratios must sum to 1, and it is mutually exclusive with `task_ids_test` / `project_ids_test` |
 | `class_exclude` | `"stalk, foreign_object"` | comma-separated string or list | Class names whose annotations are dropped, and which reserve no class index |
-| `attributes_exclude` | `None` | `dict[str, str]` or `None` | Drop annotations whose CVAT attribute value matches. Only the **first** key of the dict is ever evaluated — see below |
+| `attributes_exclude` | `None` | `dict[str, str]` or `None` | Drop annotations whose CVAT attribute value matches. Every key is evaluated, OR'd together — see below |
 | `area_segment_min` | `0` | number | Drop annotations whose COCO `area` is strictly below this. `0` is a no-op |
 | `unify_class_order` | `True` | bool (or UI string) | Build one name → index map for every source in the run. `False` restores the legacy per-source `category_id - 1` |
 | `class_names` | `""` | comma-separated string or list | Pinned class order. Empty = derive it as the sorted union of every source |
@@ -271,37 +271,32 @@ Excluding every class is caught up front: `ValueError: class map is empty: no ca
 
 ### What it actually does
 
-Read this section carefully rather than assuming the obvious semantics, because the implementation (`src/schema/coco.py:140-166`) does not do what its shape suggests.
-
 ```python
-if attributes_excluded is not None:
+if attributes_excluded:
     for attr_name, attr_value in attributes_excluded.items():
-        attributes_dataset = set(
-            ann.attributes.get(attr_name).replace(", ", ",").replace(" ,", ",").split(",")
-        )
-        attributes_config = set(
-            attr_value.replace(", ", ",").replace(" ,", ",").split(",")
-        )
-        if attributes_dataset is None:
+        raw = ann.attributes.get(attr_name)
+        if raw is None:
             continue
 
-        if isinstance(attributes_dataset, set):
-            intersection = attributes_config.intersection(attributes_dataset)
-            if intersection:
-                ...
-                skip = True
-                break
-            break
+        report.attr_keys_seen.add(attr_name)
+        intersection = _attribute_values(attr_value) & _attribute_values(raw)
+        if intersection:
+            ...
+            skip = True
+            break  # OR semantics: one matching rule is enough
 ```
 
 Behaviour, item by item:
 
-- **The intended semantics.** `{"maturity_truth": "background"}` means: read the annotation's `maturity_truth` attribute, split both it and the configured value on commas, and drop the annotation if the two sets intersect. Multi-value attributes work — `{"tags": "blurred, occluded"}` drops anything tagged either way — and the only whitespace normalisation is `", " → ","` and `" ," → ","`, so `"a ,  b"` still leaves a token `" b"` that will not match.
-- **Only the first key of the dict is ever evaluated.** Both branches of the inner `if` end in `break`: match → `skip = True; break`, no match → `break`. So `{"maturity": "background", "quality": "bad"}` filters on `maturity` and ignores `quality` entirely, silently. If you need two attribute filters, you have one.
-- **Matching is exact and case-sensitive**, on whole comma-separated tokens. `"Background"` does not match `"background"`, and `"back"` does not match `"background"`.
-- **An annotation missing the attribute crashes the run.** `ann.attributes.get(attr_name)` returns `None` when the key is absent, and `None.replace(...)` raises `AttributeError` before the `is None` guard three lines below ever runs. That guard is dead code — by the time it is reached the value is always a `set`, which is also why the `isinstance(..., set)` check is always true. In practice CVAT emits every declared attribute on every annotation of a label that declares it, so this only bites when the attribute is declared on *some* labels: the first annotation of an unattributed label ends the run.
-- **Non-string attribute values crash the same way.** `Annotation.attributes` is typed `dict`, so a checkbox attribute arriving as a JSON boolean has no `.replace`.
+- **The semantics.** `{"maturity_truth": "background"}` means: read the annotation's `maturity_truth` attribute, split both it and the configured value on commas, and drop the annotation if the two sets intersect. Multi-value attributes work — `{"tags": "blurred, occluded"}` drops anything tagged either way.
+- **Every key is evaluated, and they are OR'd.** `{"maturity": "background", "quality": "bad"}` drops an annotation that matches *either* rule. Each entry stands alone as one exclusion, so adding a rule tightens the filter rather than loosening it, and the order the keys are written in cannot change the result. This is worth stating because OR and AND are indistinguishable on a single-key config, which is what a first attempt always uses.
+- **Comparison folds case and surrounding space**, on whole comma-separated tokens. `"Background"`, `"BACKGROUND"` and `" background "` all match `"background"`; `"back"` does not. This matches how `class_exclude` compares names.
+- **An annotation that does not carry the attribute is not a match.** CVAT writes an attribute only onto annotations of the labels that declare it, so in any project with more than one label most annotations are missing most attributes. Such an annotation is left for the remaining rules to judge, and kept if none of them match.
+- **Non-string attribute values are coerced with `str()`** before comparison, because `Annotation.attributes` is an untyped `dict` and a checkbox attribute arrives as a JSON boolean. Write the config value as text: `{"is_blurry": "true"}`.
+- **An empty configured value matches nothing.** `{"maturity_truth": ""}` drops no annotations rather than matching every annotation with an empty attribute.
 - **The filter runs after the area filter and before the class filter**, and a match sets `skip = True` rather than `continue`, so the class filter still evaluates. That only affects which reason is recorded, not the outcome.
+
+All of the above is asserted by `tests/data/test_attributes_exclude.py`. Until [issue #20](https://github.com/agfianf/template-yolov8-clearml/issues/20) was fixed, only the first key was evaluated and a missing attribute raised `AttributeError`; a config written before that fix may have been silently filtering on one rule out of several.
 
 ### Valid values
 
@@ -321,6 +316,14 @@ Nothing on its own at INFO. The count folds into the per-source annotation summa
 ```
 
 At `LOG_LEVEL=debug` you additionally get one line per annotation: `ann 88431 dropped: attribute maturity_truth in ['background']`.
+
+One WARNING is possible, emitted once at the end of the data stage rather than per source:
+
+```
+2026-07-31 09:20:44 | WARNING | src.yolov8.dataset_report | attributes_exclude: 'occluded' not carried by any annotation in any source, so nothing was dropped for it -- check the attribute name
+```
+
+It fires only when *no* source in the run carried the attribute, which in practice means the name is misspelt. A rule aimed at one CVAT task and absent from another is normal and stays silent. This exists because treating a missing attribute as "no match" is what makes a typo silent — before the fix a bad name announced itself by crashing.
 
 ---
 
@@ -590,7 +593,7 @@ Most common wins, so `speed_limit` is the displayed name. Fix it in CVAT anyway 
 3. **Ratios that do not sum to 1 with `test_ratio` set.** `0.8 / 0.2 / 0.1` sums to 1.1 and is rejected. Each ratio is that split's share of the dataset; write `0.7 / 0.2 / 0.1`.
 4. **Configuring `test_ratio` *and* `task_ids_test`.** Refused — they are two ways of producing the same `test/` directory. Pick one.
 5. **Spelling `class_exclude` with different case from CVAT.** The class map drops the name case-insensitively but the annotation filter matches case-sensitively, so the run dies with `UnknownClassError` naming a class you *did* exclude.
-6. **Putting two keys in `attributes_exclude`.** Only the first is evaluated, silently. And an annotation that does not carry the attribute crashes the run with `AttributeError`.
+6. **Misspelling an attribute name in `attributes_exclude`.** Nothing is dropped, and the run completes — the only signal is one WARNING at the end of the data stage naming the attribute.
 7. **Reading `area_segment_min` as a fraction.** It is square pixels at source resolution.
 8. **Fine-tuning with a derived class order.** Adding or excluding one class renumbers everything after it alphabetically. Pin `class_names` to the checkpoint's `names`.
 9. **Turning `unify_class_order` off to "make the old numbers come back".** It restores per-source `category_id - 1`, which is the bug, not a numbering scheme. Use it only to reproduce a specific historical run.

--- a/src/params.py
+++ b/src/params.py
@@ -177,7 +177,14 @@ args_data = {
     # A class the pinned list does not mention: `error` or `drop`. Unreachable when
     # class_names is empty, since a derived map contains every class by construction.
     "on_unknown_class": "error",
-    # "attributes_exclude": {"maturity_truth": "background"},  # noqa: ERA001
+    # Drop annotations by CVAT attribute. Every key is evaluated and they are OR'd:
+    # the example below drops an annotation that is `background` OR occluded. An
+    # annotation whose label does not declare the attribute simply does not match.
+    # Values are compared case-insensitively, and a comma lists alternatives.
+    # "attributes_exclude": {  # noqa: ERA001
+    #     "maturity_truth": "background",  # noqa: ERA001
+    #     "occluded_truth": "yes",  # noqa: ERA001
+    # },
     "attributes_exclude": None,
     "area_segment_min": 0,
 }

--- a/src/schema/coco.py
+++ b/src/schema/coco.py
@@ -9,6 +9,20 @@ from src.utils.logging import Tally, get_logger
 logger = get_logger(__name__)
 
 
+def _attribute_values(raw: object) -> set[str]:
+    """Split one CVAT attribute value into comparable tokens.
+
+    `Annotation.attributes` is an untyped dict, so a checkbox attribute arrives as
+    a `bool` and a number attribute as an `int`; `str()` lets those compare against
+    the text in the config instead of dying on `.replace`. Case is folded for the
+    same reason the class filter folds it -- a CVAT value spelled `Background` and
+    a config spelling `background` mean the same thing. Commas separate values on
+    both sides, so one rule can list alternatives and a multi-select attribute
+    matches on any of them.
+    """
+    return {token.strip().lower() for token in str(raw).split(",") if token.strip()}
+
+
 @dataclass
 class FilterReport:
     """What annotation filtering did, as counts rather than as a line per item."""
@@ -18,6 +32,12 @@ class FilterReport:
     dropped_area: int = 0
     dropped_class: Tally = field(default_factory=Tally)
     dropped_attr: Tally = field(default_factory=Tally)
+    # Which `attributes_exclude` names were configured, and which of them any
+    # annotation in this source actually carried. A name missing from one source
+    # is normal; missing from every source is a typo, and the run-level warning
+    # in src/yolov8/dataset_report.py is the only thing that says so.
+    attr_rules: set[str] = field(default_factory=set)
+    attr_keys_seen: set[str] = field(default_factory=set)
 
     @property
     def dropped(self) -> int:
@@ -117,6 +137,14 @@ class Coco(BaseModel):
         Filters are applied at the annotation level. The per-annotation decisions
         are tallied and logged as one INFO line; individual decisions go to DEBUG,
         because there is one per annotation and a dataset has tens of thousands.
+
+        `attributes_excluded` is **OR** across its keys: an annotation is dropped as
+        soon as any one rule matches it, and every key is evaluated. Each entry
+        stands alone as "drop annotations whose <attribute> is <value>", so adding
+        a rule tightens the filter. Say this out loud because OR and AND are
+        indistinguishable on a single-key config, which is what everybody tests
+        with. An annotation that does not carry the attribute at all cannot match
+        the rule and is left to the remaining rules to judge.
         """
         if exclude_class is None:
             exclude_class = []
@@ -127,6 +155,8 @@ class Coco(BaseModel):
         logger.debug("categories: %s", id2label)
 
         report = FilterReport(total=len(self.annotations or []))
+        if attributes_excluded:
+            report.attr_rules.update(attributes_excluded)
 
         for ann in self.annotations or []:
             skip = False
@@ -137,32 +167,31 @@ class Coco(BaseModel):
                 report.dropped_area += 1
                 continue
 
-            if attributes_excluded is not None:
+            if attributes_excluded:
                 for attr_name, attr_value in attributes_excluded.items():
-                    attributes_dataset = set(
-                        ann.attributes.get(attr_name)
-                        .replace(", ", ",")
-                        .replace(" ,", ",")
-                        .split(",")
-                    )
-                    attributes_config = set(
-                        attr_value.replace(", ", ",").replace(" ,", ",").split(",")
-                    )
-                    if attributes_dataset is None:
+                    raw = ann.attributes.get(attr_name)
+                    if raw is None:
+                        # CVAT writes an attribute only onto annotations of the
+                        # labels that declare it, so an absent key is ordinary and
+                        # simply means this rule cannot match here. It used to call
+                        # .replace() on the None and kill the run.
                         continue
 
-                    if isinstance(attributes_dataset, set):
-                        intersection = attributes_config.intersection(attributes_dataset)
-                        if intersection:
-                            logger.debug(
-                                "ann %s dropped: attribute %s in %s",
-                                ann.id,
-                                attr_name,
-                                sorted(intersection),
-                            )
-                            report.dropped_attr.add(attr_name, ann.id)
-                            skip = True
-                            break
+                    report.attr_keys_seen.add(attr_name)
+                    intersection = _attribute_values(attr_value) & _attribute_values(raw)
+                    if intersection:
+                        logger.debug(
+                            "ann %s dropped: attribute %s in %s",
+                            ann.id,
+                            attr_name,
+                            sorted(intersection),
+                        )
+                        report.dropped_attr.add(attr_name, ann.id)
+                        skip = True
+                        # OR semantics: one matching rule is enough, and the tally
+                        # records the rule that did it. A rule that does *not* match
+                        # falls through to the next one -- an unconditional break
+                        # here meant only the first key was ever evaluated.
                         break
 
             # Normalized the same way the class map matches names

--- a/src/yolov8/data.py
+++ b/src/yolov8/data.py
@@ -23,7 +23,10 @@ from src.data.task_scope import resolve_task_scope
 from src.schema.coco import Coco as CocoSchema
 from src.utils.general import read_json
 from src.utils.logging import get_logger
-from src.yolov8.dataset_report import report_dataset_composition
+from src.yolov8.dataset_report import (
+    report_dataset_composition,
+    warn_unmatched_attribute_rules,
+)
 
 
 logger = get_logger(__name__)
@@ -363,6 +366,9 @@ class DataHandler:
 
         # Once per data stage, after every source has been converted -- class balance and
         # object geometry are properties of the whole dataset, not of one CVAT task.
+        # So is "this attributes_exclude rule matched nothing anywhere", which is why it
+        # waits until here rather than firing per source.
+        warn_unmatched_attribute_rules()
         report_dataset_composition()
 
     def export(self) -> str:

--- a/src/yolov8/dataset_report.py
+++ b/src/yolov8/dataset_report.py
@@ -55,6 +55,8 @@ class DatasetStats:
         self.dropped_area = 0
         self.dropped_class: Counter[str] = Counter()
         self.dropped_attr: Counter[str] = Counter()
+        self.attr_rules: set[str] = set()
+        self.attr_keys_seen: set[str] = set()
 
     def reset(self) -> None:
         """Clear everything, so a second data stage does not stack onto the first."""
@@ -87,6 +89,14 @@ class DatasetStats:
                 target.update(dict(tally))
             except Exception as e:
                 logger.debug("could not fold a filter tally: %s", e)
+        # getattr, for the same reason the loop above is wrapped: callers pass
+        # report-shaped objects, and a missing field should not cost a data stage.
+        self.attr_rules |= set(getattr(report, "attr_rules", ()))
+        self.attr_keys_seen |= set(getattr(report, "attr_keys_seen", ()))
+
+    def unmatched_attribute_rules(self) -> list[str]:
+        """`attributes_exclude` names no annotation carried, in any source."""
+        return sorted(self.attr_rules - self.attr_keys_seen)
 
     @property
     def is_empty(self) -> bool:
@@ -135,6 +145,31 @@ class DatasetStats:
 # the report is emitted once at the end of the data stage. Only ever touched in the main
 # process -- the data stage runs before any dataloader exists.
 dataset_stats = DatasetStats()
+
+
+def warn_unmatched_attribute_rules(stats: DatasetStats | None = None) -> list[str]:
+    """Warn once per run about `attributes_exclude` names nothing ever carried.
+
+    Absent from one source proves nothing: CVAT writes an attribute only onto the
+    labels that declare it, so a rule aimed at one task legitimately finds nothing
+    in another, and warning per source would cry wolf on a correct config. Absent
+    from *every* source is a different claim, and almost always a misspelt
+    attribute name. That case used to announce itself by crashing on `None`;
+    treating a missing attribute as "no match" is what makes it silent, so this is
+    the replacement signal, not an extra.
+
+    Deliberately outside `report_dataset_composition`, which returns early without
+    a ClearML task -- a typo is worth hearing about on a local run too.
+    """
+    stats = stats if stats is not None else dataset_stats
+    unmatched = stats.unmatched_attribute_rules()
+    if unmatched:
+        logger.warning(
+            "attributes_exclude: %s not carried by any annotation in any source, so "
+            "nothing was dropped for it -- check the attribute name",
+            ", ".join(f"'{name}'" for name in unmatched),
+        )
+    return unmatched
 
 
 def _imbalance_figure(df: pd.DataFrame) -> go.Figure:

--- a/tests/data/test_attributes_exclude.py
+++ b/tests/data/test_attributes_exclude.py
@@ -1,0 +1,243 @@
+"""Regression tests for `attributes_exclude` (issue #20).
+
+Two defects shipped together and hid each other. Only the first key of the dict
+was evaluated, because every path out of the loop body was a `break`; and an
+annotation that did not carry the attribute crashed on
+`ann.attributes.get(name).replace(...)`. A bogus key placed second therefore
+never crashed -- it was never reached -- while the same key placed first killed
+the run, so behaviour depended on dict insertion order, which nobody controls
+when the value comes back from the ClearML UI.
+
+The feature had exactly one appearance in the suite before this file, as `None`.
+"""
+
+import logging
+
+import pytest
+
+from src.schema.coco import Coco as CocoSchema
+from src.yolov8.dataset_report import DatasetStats, warn_unmatched_attribute_rules
+
+
+def _payload(annotations: list[dict]) -> dict:
+    return {
+        "licenses": [],
+        "info": {
+            "year": "2026",
+            "version": "1",
+            "description": "",
+            "contributor": "",
+            "url": "",
+            "date_created": "",
+        },
+        "categories": [{"id": 1, "name": "fruit", "supercategory": ""}],
+        "images": [
+            {
+                "id": 1,
+                "width": 64,
+                "height": 64,
+                "file_name": "img_1.jpg",
+                "license": 0,
+                "flickr_url": None,
+                "coco_url": None,
+                "date_captured": 0,
+            }
+        ],
+        "annotations": annotations,
+    }
+
+
+def _ann(ann_id: int, attributes: dict) -> dict:
+    x = float(ann_id % 5) * 10.0
+    return {
+        "id": ann_id,
+        "image_id": 1,
+        "category_id": 1,
+        "segmentation": [[x, 0.0, x + 10, 0.0, x + 10, 10.0, x, 10.0]],
+        "area": 100.0,
+        "bbox": [x, 0.0, 10.0, 10.0],
+        "iscrowd": 0,
+        "attributes": attributes,
+    }
+
+
+def _filter(annotations: list[dict], config: dict | None):
+    """Run the filter and return (kept annotation ids, report)."""
+    kept, report = CocoSchema(**_payload(annotations)).get_imageid_to_annotations(
+        attributes_excluded=config
+    )
+    return sorted(ann.id for anns in kept.values() for ann in anns), report
+
+
+# Three annotations, and each of the two rules below matches exactly one of them.
+THREE = [
+    _ann(1, {"maturity_truth": "background", "occluded_truth": "no"}),
+    _ann(2, {"maturity_truth": "ripe", "occluded_truth": "yes"}),
+    _ann(3, {"maturity_truth": "ripe", "occluded_truth": "no"}),
+]
+TWO_RULES = {"maturity_truth": "background", "occluded_truth": "yes"}
+
+
+# --------------------------------------------------------------------------
+# Defect 1: only the first key was evaluated
+# --------------------------------------------------------------------------
+
+
+def test_every_key_is_evaluated() -> None:
+    kept, report = _filter(THREE, TWO_RULES)
+
+    assert kept == [3]
+    # Both rules are credited, so the breakdown cannot pass off a skipped rule as
+    # one that legitimately matched nothing.
+    assert report.dropped_attr["maturity_truth"] == 1
+    assert report.dropped_attr["occluded_truth"] == 1
+
+
+def test_key_order_does_not_change_the_dataset() -> None:
+    forward, _ = _filter(THREE, TWO_RULES)
+    reversed_cfg = dict(reversed(list(TWO_RULES.items())))
+    backward, _ = _filter(THREE, reversed_cfg)
+
+    assert forward == backward == [3]
+
+
+def test_a_rule_that_matches_nothing_keeps_everything() -> None:
+    kept, report = _filter(THREE, {"maturity_truth": "unripe"})
+
+    assert kept == [1, 2, 3]
+    assert not report.dropped_attr
+
+
+# --------------------------------------------------------------------------
+# Defect 2: an annotation without the attribute
+# --------------------------------------------------------------------------
+
+
+def test_annotation_without_the_attribute_is_kept_not_crashed() -> None:
+    annotations = [_ann(10, {"maturity_truth": "ripe"}), _ann(11, {})]
+
+    kept, _ = _filter(annotations, {"maturity_truth": "background"})
+
+    assert kept == [10, 11]
+
+
+def test_a_later_rule_still_applies_when_an_earlier_key_is_absent() -> None:
+    """The combination neither fix reaches alone.
+
+    Rule 1's key is missing on this annotation, so the old code died before rule
+    2 -- which does match -- was ever consulted.
+    """
+    annotations = [_ann(20, {"occluded_truth": "yes"})]
+
+    kept, report = _filter(annotations, TWO_RULES)
+
+    assert kept == []
+    assert report.dropped_attr["occluded_truth"] == 1
+
+
+def test_a_missing_key_does_not_count_as_a_match() -> None:
+    kept, _ = _filter([_ann(30, {})], {"maturity_truth": "background"})
+
+    assert kept == [30]
+
+
+# --------------------------------------------------------------------------
+# Value comparison
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["Background", "BACKGROUND", " background "])
+def test_values_compare_case_and_space_insensitively(value: str) -> None:
+    """Matched to the class filter, which lowercases for the same reason."""
+    annotations = [_ann(40, {"maturity_truth": value})]
+
+    kept, _ = _filter(annotations, {"maturity_truth": "background"})
+
+    assert kept == []
+
+
+def test_non_string_attribute_values_are_coerced() -> None:
+    """A CVAT checkbox arrives as a bool and used to die on `.replace`."""
+    annotations = [_ann(50, {"is_blurry": True}), _ann(51, {"is_blurry": False})]
+
+    kept, _ = _filter(annotations, {"is_blurry": "true"})
+
+    assert kept == [51]
+
+
+def test_commas_list_alternatives_on_both_sides() -> None:
+    annotations = [
+        _ann(60, {"flags": "occluded, truncated"}),
+        _ann(61, {"flags": "clean"}),
+    ]
+
+    kept, _ = _filter(annotations, {"flags": "truncated,unknown"})
+
+    assert kept == [61]
+
+
+def test_an_empty_rule_value_drops_nothing() -> None:
+    kept, _ = _filter([_ann(70, {"maturity_truth": ""})], {"maturity_truth": ""})
+
+    assert kept == [70]
+
+
+def test_no_config_is_a_no_op() -> None:
+    for config in (None, {}):
+        kept, report = _filter(THREE, config)
+        assert kept == [1, 2, 3]
+        assert not report.attr_rules
+
+
+# --------------------------------------------------------------------------
+# The run-level warning that replaces the crash
+# --------------------------------------------------------------------------
+
+
+def test_an_attribute_absent_everywhere_is_warned_about_once() -> None:
+    _kept, report = _filter(THREE, {"has_longstalk": "yes"})
+    stats = DatasetStats()
+    stats.note_filter_report(report)
+
+    assert stats.unmatched_attribute_rules() == ["has_longstalk"]
+
+
+def test_an_attribute_present_in_only_one_source_is_not_warned_about() -> None:
+    """The false alarm the per-source version of this warning would have raised.
+
+    CVAT writes an attribute only onto labels that declare it, so a task without
+    the label carries the rule's key nowhere -- while the config is correct.
+    """
+    _kept_a, report_a = _filter(THREE, TWO_RULES)
+    _kept_b, report_b = _filter([_ann(80, {"maturity_truth": "ripe"})], TWO_RULES)
+
+    stats = DatasetStats()
+    stats.note_filter_report(report_a)
+    stats.note_filter_report(report_b)
+
+    assert stats.unmatched_attribute_rules() == []
+
+
+def test_the_warning_names_the_attribute(caplog: pytest.LogCaptureFixture) -> None:
+    _kept, report = _filter(THREE, {"has_longstalk": "yes"})
+    stats = DatasetStats()
+    stats.note_filter_report(report)
+
+    with caplog.at_level(logging.WARNING):
+        unmatched = warn_unmatched_attribute_rules(stats)
+
+    assert unmatched == ["has_longstalk"]
+    assert "has_longstalk" in caplog.text
+
+
+def test_nothing_is_warned_about_without_a_config(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _kept, report = _filter(THREE, None)
+    stats = DatasetStats()
+    stats.note_filter_report(report)
+
+    with caplog.at_level(logging.WARNING):
+        caplog.clear()  # the filter itself logs its INFO summary during setup
+        assert warn_unmatched_attribute_rules(stats) == []
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []


### PR DESCRIPTION
Closes #20.

## The two defects, and why they hid each other

Every path out of the attribute loop body was a `break` — one on a match, one on no match — so **only the first key of the dict was ever evaluated**. A second rule was ignored silently: nothing raised, and the summary line reported a real count of real drops under the one attribute that was honoured, which reads exactly like a rule that legitimately matched nothing. The annotations the second rule was meant to remove went on into training. And since it was the first key *by insertion order*, the same pair of rules written the other way round produced a different dataset.

Separately, `ann.attributes.get(attr_name).replace(...)` raised `AttributeError` on any annotation that did not carry the attribute. CVAT writes an attribute only onto annotations of the labels that declare it, so any project with more than one label hits this on its first unattributed annotation.

The interaction is why both survived this long: a misspelt attribute name placed *second* never crashed, because it was never reached. Whether a bad config killed the run or quietly halved the filter depended on where it sat in the dict.

## Behaviour, before and after

Fixture: three annotations — ann 1 `{maturity_truth: background, occluded_truth: no}`, ann 2 `{maturity_truth: ripe, occluded_truth: yes}`, ann 3 `{maturity_truth: ripe, occluded_truth: no}`.

| config | before | after |
|---|---|---|
| `{maturity_truth: background, occluded_truth: yes}` | kept `[2, 3]` — ann 2 leaks through | kept `[3]` |
| same two rules, keys reversed | kept `[1, 3]` — **a different dataset** | kept `[3]` |
| annotation missing the attribute | `AttributeError`, no dataset at all | kept |
| attribute value `Background` vs config `background` | kept, silently | dropped |
| checkbox attribute (`True`) | `AttributeError` on `bool` | dropped |
| attribute name that exists nowhere | `AttributeError` — unless placed second, then silent | kept, one WARNING |

## What changed

**Every key is evaluated, OR'd.** An annotation is dropped as soon as one rule matches, so each entry stands alone as an independent exclusion and adding a rule *tightens* the filter. OR rather than AND because under AND an operator tightening their config would get more annotations, which is the opposite of what an exclude list should do. Stated in the docstring and the docs, since the two are indistinguishable on the single-key config everybody tests with.

**A missing attribute is not a match.** It is ordinary, not a config error, and the annotation is left for the remaining rules to judge.

**Values are coerced with `str()`** so a checkbox attribute arriving as a bool compares instead of raising, and compared case-insensitively — matching how `class_exclude` has compared names since the `Stalk`/`stalk` fix.

**One run-level WARNING** naming any configured attribute that no annotation carried in *any* source. Treating a missing attribute as "no match" is precisely what turns a typo from a crash into silence, so this is the replacement signal rather than an extra. Run-level and not per-source: absent from one CVAT task is normal, absent from all of them is a misspelling — a per-source warning would cry wolf on a correct config. It sits outside `report_dataset_composition()`, which returns early when there is no ClearML task; a typo is worth hearing on a local run too.

**Both dead checks removed** rather than left to imply a guard that was not there: `attributes_dataset is None` could not fire on a set built three lines above, and `isinstance(..., set)` was true for the same reason.

## Tests

`tests/data/test_attributes_exclude.py`, 17 cases — the feature previously appeared in the suite exactly once, as `None`. The two that carry the most weight:

- `test_key_order_does_not_change_the_dataset` — the same rules in either order must produce the same kept set, which fails on the whole of defect 1 in one assertion.
- `test_a_later_rule_still_applies_when_an_earlier_key_is_absent` — needs both fixes at once; the old code died before the matching rule was consulted.

Full suite: 354 passed, ignoring the modules that are stale at HEAD (`test_integration.py`, `test_method_cvat_{http,sdk}.py`, and `test_converter_coco2yolov.py`, which needs real CVAT data under `tmp_dir_cvat/` and fails identically on `main`).

## Docs

`docs/configurations/2_data.md` documented the broken behaviour as fact — the table row, the walkthrough and gotcha #6 all described "only the first key is evaluated". All updated, with the OR semantics and the new WARNING written down. The commented example in `src/params.py` now shows two keys, so the OR shape is visible where people first switch the feature on.

## Noticed, not fixed — out of scope

Gotcha #5 in `2_data.md` still says the class filter matches case-sensitively. That stopped being true when `src/schema/coco.py` started doing `.strip().lower()` on both sides; the docs lag the code.
